### PR TITLE
Adjust MCMINI.h to be a C header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ set(MC_CPP_FILES
         MCSharedTransition.cpp MCSharedTransition.h
         MCMINIWrappers.h
         MCTransition.cpp MCTransition.h
-        MCMINI.cpp MCMINI.h
+        MCMINI_Private.cpp MCMINI_Private.h
         MCState.cpp MCState.h MC_Private.h MCConstants.h
         transitions/threads/MCThreadStart.cpp transitions/threads/MCThreadStart.h
         MCTransitionFactory.cpp MCTransitionFactory.h
@@ -71,7 +71,11 @@ set(MC_CPP_FILES
         transitions/threads/MCThreadReachGoal.cpp
         transitions/wrappers/MCGlobalVariableWrappers.cpp
         MCCommon.c MCCommon.h
-        MCEnv.h transitions/threads/MCThreadEnterGoalCriticalSection.cpp transitions/threads/MCThreadEnterGoalCriticalSection.h transitions/threads/MCThreadExitGoalCriticalSection.cpp transitions/threads/MCThreadExitGoalCriticalSection.h)
+        MCEnv.h transitions/threads/MCThreadEnterGoalCriticalSection.cpp 
+				transitions/threads/MCThreadEnterGoalCriticalSection.h
+				transitions/threads/MCThreadExitGoalCriticalSection.cpp 
+				transitions/threads/MCThreadExitGoalCriticalSection.h
+        MCMINI.h)
 
 add_executable(MCMINI ${MC_CPP_FILES} ${MC_C_FILES} ${MAIN_FUNCTION})
 message("Linking object files...")

--- a/src/MCMINI.h
+++ b/src/MCMINI.h
@@ -1,47 +1,9 @@
-#ifndef MC_MC_H
-#define MC_MC_H
+#ifndef MCMINI_MCMINI_H
+#define MCMINI_MCMINI_H
 
 #include "MCShared.h"
-#include "MCSharedTransition.h"
-#include "MCDeferred.h"
-
-extern "C" {
-    #include <semaphore.h>
-    #include "mc_shared_cv.h"
-}
-
-/* Synchronization primitives */
-extern MC_THREAD_LOCAL tid_t tid_self;
-extern pid_t cpid;
-extern mc_shared_cv (*threadQueue)[MAX_TOTAL_THREADS_IN_PROGRAM];
-
-/*
- * Allows new threads to be created in a race-free manner
- */
-extern sem_t mc_pthread_create_binary_sem;
-extern trid_t traceId;
-
-/* Data transfer */
-extern void *shmStart;
-extern MCSharedTransition *shmTransitionTypeInfo;
-extern void *shmTransitionData;
-extern const size_t shmAllocationSize;
-
-/* State */
-extern MCDeferred<MCState> programState;
+#include "MCMINIWrappers.h"
 
 MC_CTOR void mc_init();
-void mc_child_panic();
-void mc_report_undefined_behavior(const char*);
 
-#define MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(x, str) \
-do {                                              \
-    if (!static_cast<bool>(x)) {                  \
-        mc_report_undefined_behavior(static_cast<const char*>(str));      \
-    }                                             \
-} while(0)
-
-#define MC_REPORT_UNDEFINED_BEHAVIOR(str) MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(false, str)
-
-
-#endif //MC_MC_H
+#endif //MCMINI_MCMINI_H

--- a/src/MCMINIWrappers.cpp
+++ b/src/MCMINIWrappers.cpp
@@ -1,2 +1,2 @@
 #include "MCMINIWrappers.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"

--- a/src/MCMINI_Private.cpp
+++ b/src/MCMINI_Private.cpp
@@ -1,4 +1,4 @@
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "MC_Private.h"
 #include "MCSharedTransition.h"
 #include "MCTransitionFactory.h"

--- a/src/MCMINI_Private.h
+++ b/src/MCMINI_Private.h
@@ -1,0 +1,48 @@
+#ifndef MC_MC_H
+#define MC_MC_H
+
+#include "MCShared.h"
+#include "MCSharedTransition.h"
+#include "MCDeferred.h"
+#include "MCMINIWrappers.h"
+
+extern "C" {
+    #include <semaphore.h>
+    #include "mc_shared_cv.h"
+}
+
+/* Synchronization primitives */
+extern MC_THREAD_LOCAL tid_t tid_self;
+extern pid_t cpid;
+extern mc_shared_cv (*threadQueue)[MAX_TOTAL_THREADS_IN_PROGRAM];
+
+/*
+ * Allows new threads to be created in a race-free manner
+ */
+extern sem_t mc_pthread_create_binary_sem;
+extern trid_t traceId;
+
+/* Data transfer */
+extern void *shmStart;
+extern MCSharedTransition *shmTransitionTypeInfo;
+extern void *shmTransitionData;
+extern const size_t shmAllocationSize;
+
+/* State */
+extern MCDeferred<MCState> programState;
+
+MC_CTOR void mc_init();
+void mc_child_panic();
+void mc_report_undefined_behavior(const char*);
+
+#define MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(x, str) \
+do {                                              \
+    if (!static_cast<bool>(x)) {                  \
+        mc_report_undefined_behavior(static_cast<const char*>(str));      \
+    }                                             \
+} while(0)
+
+#define MC_REPORT_UNDEFINED_BEHAVIOR(str) MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(false, str)
+
+
+#endif //MC_MC_H

--- a/src/MCShared.h
+++ b/src/MCShared.h
@@ -1,46 +1,54 @@
 #ifndef DPOR_MCSHARED_H
 #define DPOR_MCSHARED_H
 
+#ifdef __cplusplus
+#include <cassert>
+#else
 #include <assert.h>
+#endif
+
 #include "MCConstants.h"
 
 typedef uint64_t objid_t;
-typedef objid_t MCObjectID;
-typedef uint64_t MCTypeID;
 typedef void *MCSystemID;
 
-#ifndef __cplusplus
-#   define MC_EXTERN
-#   define MC_EXTERN_DECLS_BEGIN
-#   define MC_EXTERN_DECLS_END
-#else
+#ifdef __cplusplus
 #   define MC_EXTERN extern "C"
 #   define MC_EXTERN_DECLS_BEGIN extern "C" {
 #   define MC_EXTERN_DECLS_END }
+#else
+#   define MC_EXTERN
+#   define MC_EXTERN_DECLS_BEGIN
+#   define MC_EXTERN_DECLS_END
 #endif
 
-#ifndef __cplusplus
+#ifdef __cplusplus
 #   define MC_THREAD_LOCAL thread_local
 #else
 #   define MC_THREAD_LOCAL __thread
 #endif
 
-#ifndef __cplusplus
-#   define MC_NO_RETURN
-#else
+#ifdef __cplusplus
 #   define MC_NO_RETURN [[noreturn]]
+#else
+#   define MC_NO_RETURN
 #endif
 
 #define MC_ASSERT(__X) assert(__X)
-#define MC_FAIL() MC_ASSERT(0)
+
+#ifdef __cplusplus
 #define MC_FATAL_ON_FAIL(expr) \
 do {                            \
     (static_cast <bool> (expr) ? void (0) : abort()); \
 } while(0)
+#else
+#define MC_FATAL_ON_FAIL(expr) \
+do {                            \
+    ((expr) ? void (0) : abort()); \
+} while(0)
+#endif
 
 #define MC_FATAL() abort()
-#define MC_UNIMPLEMENTED() MC_ASSERT(false)
-
 #define MC_STRUCT_DECL(type)             \
 typedef struct type type;           \
 typedef struct type *type##_t;      \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 //#include <semaphore.h>
 #include "MCMINIWrappers.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 
 /*
 This program provides a possible solution for producer-consumer problem using mutex and mc_semaphore.

--- a/src/transitions/MCTransitionsShared.h
+++ b/src/transitions/MCTransitionsShared.h
@@ -4,7 +4,7 @@
 #include <pthread.h>
 #include <typeinfo>
 #include "MCShared.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "transitions/threads/MCThreadDefs.h"
 #include "transitions/mutex/MCMutexDefs.h"
 #include "transitions/semaphore/MCSemaphoreDefs.h"

--- a/src/transitions/barrier/MCBarrierEnqueue.cpp
+++ b/src/transitions/barrier/MCBarrierEnqueue.cpp
@@ -1,5 +1,5 @@
 #include "MCBarrierEnqueue.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 
 MCTransition*
 MCReadBarrierEnqueue(const MCSharedTransition *shmTransition, void *shmData, MCState *state)

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -1,5 +1,5 @@
 #include "MCCondBroadcast.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "transitions/mutex/MCMutexTransition.h"
 
 MCTransition*

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -1,5 +1,5 @@
 #include "MCCondEnqueue.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "transitions/mutex/MCMutexTransition.h"
 #include "transitions/mutex/MCMutexUnlock.h"
 #include "MCTransitionFactory.h"

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -1,5 +1,5 @@
 #include "MCCondSignal.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "transitions/mutex/MCMutexTransition.h"
 
 MCTransition*

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -1,5 +1,5 @@
 #include "MCCondWait.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "transitions/mutex/MCMutexTransition.h"
 #include "transitions/mutex/MCMutexLock.h"
 #include "MCTransitionFactory.h"

--- a/src/transitions/mutex/MCMutexLock.cpp
+++ b/src/transitions/mutex/MCMutexLock.cpp
@@ -1,4 +1,4 @@
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "MCMutexLock.h"
 #include "transitions/threads/MCThreadCreate.h"
 #include "MCMutexUnlock.h"

--- a/src/transitions/mutex/MCMutexUnlock.cpp
+++ b/src/transitions/mutex/MCMutexUnlock.cpp
@@ -1,4 +1,4 @@
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "MCMutexUnlock.h"
 #include "MCTransitionFactory.h"
 

--- a/src/transitions/semaphore/MCSemEnqueue.cpp
+++ b/src/transitions/semaphore/MCSemEnqueue.cpp
@@ -1,7 +1,7 @@
 #include "MCSemEnqueue.h"
 #include "MCSemInit.h"
 #include "MCSemWait.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 
 MCTransition*
 MCReadSemEnqueue(const MCSharedTransition *shmTransition, void *shmData, MCState *state)

--- a/src/transitions/semaphore/MCSemPost.cpp
+++ b/src/transitions/semaphore/MCSemPost.cpp
@@ -1,4 +1,4 @@
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "MCSemPost.h"
 #include "MCSemInit.h"
 

--- a/src/transitions/semaphore/MCSemWait.cpp
+++ b/src/transitions/semaphore/MCSemWait.cpp
@@ -1,4 +1,4 @@
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "MCSemWait.h"
 #include "MCSemInit.h"
 

--- a/src/transitions/wrappers/MCThreadTransitionWrappers.cpp
+++ b/src/transitions/wrappers/MCThreadTransitionWrappers.cpp
@@ -1,5 +1,5 @@
 #include "MCThreadTransitionWrappers.h"
-#include "MCMINI.h"
+#include "MCMINI_Private.h"
 #include "objects/MCThread.h"
 #include "transitions/threads/MCThreadCreate.h"
 #include "transitions/threads/MCThreadFinish.h"


### PR DESCRIPTION
What was previously `MCMINI.h` has now been moved to `MCMINI_Private.h`. You now only have to `#include MCMini.h` to use the wrapper functions plus `mc_init()`. I verified that the project still compiled as usual. There should be no functional changes to McMini as a result of this change