### PR TITLE
Add (slightly) more clever backtracking logic

### DIFF
--- a/src/MCStateStackItem.cpp
+++ b/src/MCStateStackItem.cpp
@@ -22,6 +22,12 @@ MCStateStackItem::hasThreadsToBacktrackOn() const
     return !backtrackSet.empty();
 }
 
+bool
+MCStateStackItem::isBacktrackingOnThread(tid_t tid) const
+{
+    return this->backtrackSet.count(tid) > 0;
+}
+
 tid_t
 MCStateStackItem::popFirstThreadToBacktrackOn()
 {

--- a/src/MCStateStackItem.h
+++ b/src/MCStateStackItem.h
@@ -19,6 +19,7 @@ public:
     std::unordered_set<tid_t> getEnabledThreadsInState();
 
     bool hasThreadsToBacktrackOn() const;
+    bool isBacktrackingOnThread(tid_t) const;
     tid_t popFirstThreadToBacktrackOn();
 };
 


### PR DESCRIPTION
Fixes #12 

Simply adds a check for whether the set of candidate backtracking threads (computed in the pseudocode has a nonempty intersection with the threads a particular state stack item is already backtracking on.  We can simply decide to chose a thread that is already going to be backtracked on, so we can just `return` (since we can pick _any_ candidate thread when we have a non-empty set of them, `return`-ing is equivalent to "pick a thread we're already backtracking on"). This could improve performance by potentially reducing the number of backtracking points McMini has to search