### PR TITLE
Fix `gdb` trace bug

### DIFF
--- a/src/MCMINI.h
+++ b/src/MCMINI.h
@@ -5,5 +5,4 @@
 #include "MCMINIWrappers.h"
 
 MC_CTOR void mc_init();
-
 #endif //MCMINI_MCMINI_H

--- a/src/MC_Private.h
+++ b/src/MC_Private.h
@@ -19,7 +19,7 @@ MC_PROGRAM_TYPE mc_scheduler_main();
 void mc_exhaust_threads(std::shared_ptr<MCTransition>);
 MC_PROGRAM_TYPE mc_readvance_main(std::shared_ptr<MCTransition>);
 void mc_create_initial_scheduler_state();
-void mc_exit();
+void mc_exit(int);
 
 /* GDB interface */
 bool mc_should_enter_gdb_debugging_session_with_trace_id(trid_t);
@@ -49,7 +49,7 @@ MC_PROGRAM_TYPE mc_spawn_child();
 MC_PROGRAM_TYPE mc_spawn_child_following_transition_stack();
 MC_PROGRAM_TYPE mc_begin_target_program_at_main(bool spawnDaemonThread);
 void mc_run_thread_to_next_visible_operation(tid_t);
-void mc_child_kill();
+void mc_kill_child();
 void mc_child_wait();
 
 /* Thread control */

--- a/src/transitions/wrappers/MCSharedLibraryWrappers.c
+++ b/src/transitions/wrappers/MCSharedLibraryWrappers.c
@@ -115,7 +115,7 @@ sem_wait(sem_t *sem)
 void
 exit(int status)
 {
-    mc_exit(status);
+    mc_transparent_exit(status);
 }
 
 int

--- a/src/transitions/wrappers/MCThreadTransitionWrappers.cpp
+++ b/src/transitions/wrappers/MCThreadTransitionWrappers.cpp
@@ -94,7 +94,7 @@ mc_exit_main_thread()
 }
 
 MC_NO_RETURN void
-mc_exit(int status)
+mc_transparent_exit(int status)
 {
     thread_post_visible_operation_hit(typeid(MCExitTransition), &status);
     thread_await_mc_scheduler();

--- a/src/transitions/wrappers/MCThreadTransitionWrappers.h
+++ b/src/transitions/wrappers/MCThreadTransitionWrappers.h
@@ -4,7 +4,7 @@
 #include <pthread.h>
 #include "MCShared.h"
 
-MC_EXTERN MC_NO_RETURN void mc_exit(int);
+MC_EXTERN MC_NO_RETURN void mc_transparent_exit(int);
 MC_EXTERN int mc_pthread_create(pthread_t *, const pthread_attr_t *, void *(*) (void *), void *);
 MC_EXTERN int mc_pthread_join(pthread_t, void**);
 MC_EXTERN void mc_pthread_reach_goal();


### PR DESCRIPTION
Fixes a bug with following traces using `mcmini -d`. The main issue here was that we have an `atexit()`-handler which we register _only in forked child processes_ to "catch" the main thread when it exits the main routine. The exit handler inadvertently ran after attempting to `exit()` from the _child_ process when setting the environment up for gdb. The trouble is that when we actually want to exit from the child process, we need to use `_Exit()`, which doesn't invoke any at-exit handlers, to avoid blocking in the atexit handler.

To make our lives simpler, I've introduced `mc_exit()` which calls the proper exit function (either `exit()` or `_Exit()`) based on the calling process. When the constructor is invoked, a new initialization step now takes place which marks the process id of the scheduling process as the "scheduler_pid`. A process determines if it is the scheduler by testing its own process id (`getpid()`) against the scheduler process id.

@gc00 This should unblock you