### PR TITLE
Fix small backtracking logic error

### DIFF
--- a/src/MCState.h
+++ b/src/MCState.h
@@ -94,11 +94,12 @@ private:
      * Inserts a backtracking point given a context of insertion (where in
      * the transition/state stacks to insert into etc.)
      */
-    void dynamicallyUpdateBacktrackSetsHelper(const std::shared_ptr<MCTransition> &S_i,
-                                              const std::shared_ptr<MCStateStackItem> &preSi,
-                                              const std::shared_ptr<MCTransition> &nextSP,
-                                              const std::unordered_set<tid_t> &enabledThreadsAtPreSi,
-                                              int i, int p);
+    bool dynamicallyUpdateBacktrackSetsHelper(const
+      std::shared_ptr<MCTransition> &S_i,
+      const std::shared_ptr<MCStateStackItem> &preSi,
+      const std::shared_ptr<MCTransition> &nextSP,
+      const std::unordered_set<tid_t> &enabledThreadsAtPreSi,
+      int i, int p);
 
     void incrementThreadTransitionCountIfNecessary(const std::shared_ptr<MCTransition>&);
     void decrementThreadTransitionCountIfNecessary(const std::shared_ptr<MCTransition>&);


### PR DESCRIPTION
This commit resolves an issue where the transition that just ran could be backtracked more than it needed
to be. This didn't affect the correctness of McMini but may have unnecessarily increased the number of backtracking
points. Effectively, we weren't stopping early enough in the search backwards
