### PR TITLE
Add subtle optimization when backtracking

### DIFF
--- a/src/MCStateStackItem.h
+++ b/src/MCStateStackItem.h
@@ -3,6 +3,7 @@
 
 #include "MCShared.h"
 #include "MCTransition.h"
+#include "misc/MCOptional.h"
 #include <unordered_set>
 #include <utility>
 
@@ -70,6 +71,11 @@ private:
      * run by that thread
      */
     std::unordered_set<tid_t> sleepSet;
+
+    /**
+     * @brief The thread 
+     */
+    MCOptional<tid_t> persistentSetRestartId = MCOptional<tid_t>::nil();
 
     /**
      * @brief A cache of threads that are enabled in this state
@@ -155,6 +161,19 @@ public:
      */
     void markThreadsEnabledInState(const std::unordered_set<tid_t> &threads);
 
+    /**
+     * @brief Marks the given thread as the one which, if
+     * DPOR decides to backtrack on this thread, it should add
+     * another (different) thread to the backtracking set
+     */
+    void markPersistentSetRestartId(tid_t);
+
+    
+    void backtrackWithNewPersistentSetId();
+
+
+    MCOptional<tid_t> getPersistentSetRestartId();
+    std::unordered_set<tid_t> getUnexecutedPersistentSetCandidates();
     std::unordered_set<tid_t> getEnabledThreadsInState();
     std::unordered_set<tid_t> getSleepSet();
 
@@ -164,6 +183,7 @@ public:
      */
     void addThreadToSleepSet(tid_t);
 
+    bool hasBacktrackedOnThread(tid_t) const;
 
     /**
      * @brief Whether or not there are any
@@ -185,6 +205,12 @@ public:
      * for this state
      */
     bool isBacktrackingOnThread(tid_t) const;
+
+    /**
+     * @brief 
+     * 
+     */
+    bool isPersistentSetRestartId(tid_t) const;
 
     /**
      * @brief Whether or not the given thread

--- a/src/misc/MCOptional.h
+++ b/src/misc/MCOptional.h
@@ -1,28 +1,33 @@
 #ifndef MCOPTIONAL_H
 #define MCOPTIONAL_H
 
-#include <cstdint>
 #include <stdexcept>
+#include <memory>
 
 template<typename Value>
 class MCOptional final {
     bool _hasValue;
-
-    union {
-        const Value value;
-
-
+    union { 
+        Value value;
     };
-
-    /* Construct the `nil` value */
+public:
     MCOptional() : _hasValue(false) {}
     MCOptional(Value value) : value(value), _hasValue(true) {}
 
-
-public:
-
     static MCOptional<Value>
     some(Value value)
+    {
+        return MCOptional<Value>(value);
+    }
+
+    static MCOptional<Value>
+    of(Value value)
+    {
+        return MCOptional<Value>(value);
+    }
+
+    static MCOptional<Value>
+    withValue(Value value)
     {
         return MCOptional<Value>(value);
     }
@@ -33,26 +38,11 @@ public:
         return MCOptional<Value>();
     }
 
-    /**
-     * Returns the value stored in the optional if
-     * such a value exists
-     *
-     * If the optional does not contain any underlying
-     * value, the results of accessing and using the
-     * value are undefined
-     *
-     */
     Value
-    unsafelyUnwrapped()
+    unwrapped() const
     {
-        return value;
-    }
-
-    Value
-    unwrapped()
-    {
-        if (!hasValue()) {
-            throw std::runtime_error("Attempted to unwrap the `nil` optional value");
+        if (!_hasValue) { 
+            throw std::runtime_error("Attempting to unwrap a `nil` optional value");
         }
         return value;
     }
@@ -67,6 +57,24 @@ public:
     isNil() const
     {
         return !_hasValue;
+    }
+
+    bool 
+    operator==(const Value &value) const 
+    {  
+        if (!hasValue()) return false;
+        return unwrapped() == value;
+    }
+
+    bool 
+    operator==(const MCOptional<Value> &optional) const 
+    {  
+        if (!hasValue() && !optional.hasValue()) 
+            return true;
+        else if (hasValue() && optional.hasValue())
+            return this == optional.unwrapped();
+        else 
+            return false;
     }
 };
 


### PR DESCRIPTION
Fixes #21 

This PR adds the subtle optimization described on page 6 of Flannagan and Godefroid's DPOR
paper. The semantics hopefully match that of what they describe in the paper (viz. performing another persistent set computation when we encounter the same thread to backtrack on). We attempt to avoid the persistent set re-computation whenever we can select a different thread.

The implementation assumes that the subtle optimization described in the paper is as follows:

1. Compute the set `E` as usual for `pre(S, i)`
2. When the set `E` is empty, choose any thread `p` enabled which we have not yet backtracked on (and which is not contained in the sleep set) to backtrack on. Suppose thread `q` executed in the state `pre(S, i)`
3. If we see that thread `q` is backtracked on again, repeat the process: pick yet another enabled thread `r` which we have not yet backtracked on (and which is not contained in the sleep set). If we see that thread **`p`** is backtracked on again, repeat, and so on

Importantly, we only add another thread to the backtracking set when E is empty if the _last_ thread we added was backtracked on during the new persistent set computation, not if _any_ thread in the repeated computations was backtracked on. This is where I'm a bit less certain about what they're describing