### PR TITLE
Remove use of -03 in favor of CMAKE_BUILD_TYPE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,6 @@ set(MC_CPP_FILES
         MCMINI.h)
 
 add_executable(MCMINI ${MC_CPP_FILES} ${MC_C_FILES} ${MAIN_FUNCTION})
-message("Linking object files...")
 
 # -lrt -> shared memory
 # -pthread -> libpthread.so
@@ -83,15 +82,15 @@ target_link_libraries(MCMINI PUBLIC ${MC_LINK_TARGET_FLAGS})
 
 # -g3 -> debug symbols
 #-fsanitize=undefined (-lubsan)
-target_compile_options(MCMINI PUBLIC -O3)
+target_compile_options(MCMINI PUBLIC)
 
 # Shared library
 add_library(mcminichecker SHARED ${MC_CPP_FILES} ${MC_C_FILES} ${MAIN_FUNCTION})
 target_compile_definitions(mcminichecker PUBLIC MC_SHARED_LIBRARY=1)
 target_link_libraries(mcminichecker PUBLIC ${MC_LINK_TARGET_FLAGS})
-target_compile_options(mcminichecker PUBLIC -O3)
+target_compile_options(mcminichecker PUBLIC)
 
 # Executable that loads the shared library
 set(MAIN_FUNCTION launch.c)
 add_executable(mcmini ${MAIN_FUNCTION} MCEnv.h)
-target_compile_options(mcmini PUBLIC -O3)
+target_compile_options(mcmini PUBLIC)


### PR DESCRIPTION
This commit simply removes explicit compile option `-O3` that CMake will add by default with a CMAKE_BUILD_TYPE of "Release". This means we won't have to keep changing the flag to get Release vs Debug builds. We can now simply do

```
cmake -DCMAKE_BUILD_TYPE=Release
```
to get a release build and

```
cmake -DCMAKE_BUILD_TYPE=Debug
```
to get a debug build. Specific compile options are of course still necessary; but those targeting size and speed optimizations and debug levels are mostly covered by CMake pretty well already