### PR TITLE
Add script for running tests

### DIFF
--- a/test_script
+++ b/test_script
@@ -27,7 +27,7 @@ if (args.deadlock and args.program != "" and args.directory == ""):
 
 # Running a specified deadlock program with a custom output path
 if (args.deadlock and args.program != "" and args.directory != ""):
-    os.system("(time ./mcmini ../tests/deadlock_programs" + args.program + ") 2>&1 | tee " + args.directory + args.program)
+    os.system("(time ./mcmini ../tests/deadlock_programs" + args.program + ") 2>&1 | tee " + args.directory)
 
 # Running all deadlock programs with a default output path
 if (args.deadlock and args.program == "" and args.directory == ""):
@@ -88,7 +88,7 @@ if ((not (args.deadlock)) and args.program != "" and args.directory == ""):
 
 # Running a specified non-deadlock program with a custom output path
 if ((not (args.deadlock)) and args.program != "" and args.directory != ""):
-    os.system("(time ./mcmini ../tests/programs/" + args.program + ") 2>&1 | tee " + args.directory + args.program)
+    os.system("(time ./mcmini ../tests/programs/" + args.program + ") 2>&1 | tee " + args.directory)
 
 # Running all non-deadlock programs with a default output path
 if ((not (args.deadlock)) and args.program == "" and args.directory == ""):


### PR DESCRIPTION
The way script can be used is explained below. Please check it out and see that everything works for you. Additional suggestions are always welcome.

**Running a specified program (deadlock version) with output going into the default directory (/tests/output_deadlock):**

./test_script --program philosophers_mutex --deadlock

**Running a specified program (non-deadlock version) with output going into the default directory (/tests/output_non_deadlock):**

./test_script --program philosophers_mutex

**Running a specified program (deadlock version) with output going into a specified directory:**

./test_script --program philosophers_mutex --deadlock --directory /new_deadlock_outputs/philosophers_mutex_deadlock

**Running a specified program (non-deadlock version) with output going into a specified directory:**

./test_script --program philosophers_mutex --directory /new_deadlock_outputs/philosophers_mutex_deadlock

**Running all programs (deadlock versions) with outputs going into the default directory (/tests/output_deadlock):**

./test_script --deadlock

**Running all programs (non-deadlock versions) with outputs going into the default directory (/tests/output_non_deadlock):**

./test_script

**Running all programs (deadlock versions) with outputs going into a specified directory:**

./test_script --deadlock --directory /new_deadlock_outputs/

**Running all programs (non-deadlock versions) with outputs going into a specified directory:**

./test_script --directory /new_non_deadlock_outputs/

