### PR TITLE
Improved 'make check-gdb' with 'gotoTrace'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -27,11 +27,18 @@ tests/programs/producer_consumer: tests/programs/producer_consumer.c
 	cd tests/programs && make producer_consumer
 
 check: all tests/programs/producer_consumer
-	./mcmini tests/programs/producer_consumer
+	./mcmini tests/programs/producer_consumer --quiet
 
 # If McMini was already built, first do:  'make clean'
 check-gdb: debug tests/programs/producer_consumer
-	gdb -x gdbinit --args ./mcmini tests/programs/producer_consumer
+	@ if gdb --version | grep '\<[0-9][0-9]*\.[0-9]' | \
+	 sed -e 's%^.* \([0-9][0-9]*\.[0-9]\).*$$%\1%' | grep --quiet 8; then \
+	  echo GDB version is 8.x.  Version 8.1 known to have a bug; \
+	  echo "  when using 'set detach-fork-mode 0' needed by McMini GDB."; \
+	  echo After 15 seconds, GDB will start, but it may not work properly.;\
+	  sleep 15; \
+	fi
+	gdb -x gdbinit --args ./mcmini tests/programs/producer_consumer --quiet
 
 mcmini: src/launch.c libmcmini.so
 	${CC} -g3 -O0 -Iinclude -o $@ $<

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd mcmini
 
 # To then run under GDB:
 make clean && make -j10 check-gdb
-# For syntax with GDB and other tragets, do:  make -n check-gdb
+# For syntax with GDB and other targets, do:  make -n check-gdb
 
 ## Other options:
 ```bash

--- a/gdbinit
+++ b/gdbinit
@@ -1,6 +1,9 @@
 # Configure GDB in a reasonable way
 set breakpoint pending on
 set pagination off
+# Suppress "Missing separate debuginfos" message:
+## This is now done in 'mcmini forward'
+## set build-id-verbose 0
 # GDB will track both parent and child
 set detach-on-fork off
 set print pretty
@@ -24,13 +27,15 @@ set schedule-multiple on
 
 source gdbinit_commands.py
 
+# Stop at main in scheduler.
+# Later, whenever we fork into target process, stop at main.
 break main
 run
 
-break execvp
+tbreak execvp
 continue
 
-break 'mcmini_main()'
+tbreak 'mcmini_main()'
 continue
 
 ## WE WANT TO DO:  break __real_sem_init
@@ -62,20 +67,23 @@ continue
 # break 'mc_initialize_trace_sleep_list()'
 # break *sem_init_ptr
 
-# break fork
+# tbreak fork
 # continue
 # continue
 
-# Continue through 'fork' and into target (child) process
+# Continue through 'fork' and into 'main' for target (child) process
+tbreak main
 continue
 
 ## Python nextTransition will set this:
 ## break mc_new_trace_at_current_state()
 ## break mc_shared_cv_wait_for_scheduler
 # break thread_await_scheduler_for_thread_start_transition
-# NOT NEEDED:
-#   set follow-fork-mode child
+# NOT NEEDED:  set follow-fork-mode child
+#   We 'set detach-on-fork off'
+#   So, we can set breakpoints in parent or child process, and they take effect.
 
 # Print Python-based GDB commands:
 help user-defined
-echo \n\ \ *** Type 'mcmini help' for usage. ***\n\n
+echo \n\ \ *** Type 'mcmini help' for usage. ***\n
+echo     \ \ (Do 'set print address on' for more verbose outpus.)\n\n

--- a/tests/programs/producer_consumer.c
+++ b/tests/programs/producer_consumer.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <pthread.h>
 #include <semaphore.h>
 
@@ -13,6 +14,8 @@ the solution. You can always play with these values.
 #define BufferSize 5 // Size of the buffer
 #define NUM_PRODUCERS 2
 #define NUM_CONSUMERS 1
+
+int do_print = 1;
 
 sem_t empty;
 sem_t full;
@@ -29,8 +32,10 @@ void *producer(void *pno)
         sem_wait(&empty);
         pthread_mutex_lock(&mutex);
         buffer[in] = item;
-        printf("Producer %d: Insert Item %d at %d\n",
-               *((int *)pno),buffer[in],in);
+        if (do_print) {
+          printf("Producer %d: Insert Item %d at %d\n",
+                 *((int *)pno),buffer[in],in);
+        }
         in = (in+1)%BufferSize;
         pthread_mutex_unlock(&mutex);
         sem_post(&full);
@@ -43,8 +48,10 @@ void *consumer(void *cno)
         sem_wait(&full);
         pthread_mutex_lock(&mutex);
         int item = buffer[out];
-        printf("Consumer %d: Remove Item %d from %d\n",
-               *((int *)cno),item, out);
+        if (do_print) {
+          printf("Consumer %d: Remove Item %d from %d\n",
+                 *((int *)cno),item, out);
+        }
         out = (out+1)%BufferSize;
         pthread_mutex_unlock(&mutex);
         sem_post(&empty);
@@ -52,7 +59,10 @@ void *consumer(void *cno)
     return NULL;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
+    if (argc >= 2 && strcmp(argv[1], "--quiet") == 0) {
+      do_print = 0;
+    }
     pthread_t pro[5],con[5];
 
     pthread_mutex_init(&mutex, NULL);


### PR DESCRIPTION
The extraneous printing is less verbose, and `gdbinit_commands.py` is cleaner.
A `--quiet` flags was added (`tests/programs/producer_consumer --quiet`) and `make check` and `make check-gdb` now use it.