### PR TITLE
Add support for 'abort', similar to 'exit'.

### DIFF
--- a/include/mcmini/transitions/wrappers/MCSharedLibraryWrappers.h
+++ b/include/mcmini/transitions/wrappers/MCSharedLibraryWrappers.h
@@ -15,7 +15,10 @@ extern typeof(&pthread_mutex_unlock) pthread_mutex_unlock_ptr;
 extern typeof(&sem_wait) sem_wait_ptr;
 extern typeof(&sem_post) sem_post_ptr;
 extern typeof(&sem_init) sem_init_ptr;
-extern __attribute__((__noreturn__)) typeof(&exit) exit_ptr;
+// Special declaration needed;  return type is not the implicit 'int'.
+extern __attribute__ ((__noreturn__)) typeof(&exit) exit_ptr;
+typedef __attribute__ ((__noreturn__)) void (*abort_t)();
+extern abort_t *abort_ptr;
 extern typeof(&pthread_barrier_init) pthread_barrier_init_ptr;
 extern typeof(&pthread_barrier_wait) pthread_barrier_wait_ptr;
 extern typeof(&pthread_cond_init) pthread_cond_init_ptr;
@@ -37,6 +40,7 @@ extern typeof(&sleep) sleep_ptr;
 #define __real_sem_post               (*sem_post_ptr)
 #define __real_sem_init               (*sem_init_ptr)
 #define __real_exit                   (*exit_ptr)
+#define __real_abort                  (*abort_ptr)
 #define __real_pthread_barrier_init   (*pthread_barrier_init_ptr)
 #define __real_pthread_barrier_wait   (*pthread_barrier_wait_ptr)
 #define __real_pthread_cond_init      (*pthread_cond_init_ptr)

--- a/src/transitions/wrappers/MCSharedLibraryWrappers.c
+++ b/src/transitions/wrappers/MCSharedLibraryWrappers.c
@@ -11,6 +11,10 @@ typeof(&sem_wait) sem_wait_ptr;
 typeof(&sem_post) sem_post_ptr;
 typeof(&sem_init) sem_init_ptr;
 typeof(&exit) exit_ptr;
+// Special declaration needed;  return type is not the implicit 'int'.
+typedef __attribute__ ((__noreturn__)) void (*abort_t)();
+abort_t *abort_ptr;
+// __attribute__ ((__noreturn__)) abort_t *abort_ptr;
 typeof(&pthread_barrier_init) pthread_barrier_init_ptr;
 typeof(&pthread_barrier_wait) pthread_barrier_wait_ptr;
 typeof(&pthread_cond_init) pthread_cond_init_ptr;
@@ -36,6 +40,7 @@ mc_load_intercepted_symbol_addresses()
   sem_post_ptr             = dlsym(RTLD_NEXT, "sem_post");
   sem_init_ptr             = dlsym(RTLD_NEXT, "sem_init");
   exit_ptr                 = dlsym(RTLD_NEXT, "exit");
+  abort_ptr                = dlsym(RTLD_NEXT, "abort");
   pthread_barrier_init_ptr = dlsym(RTLD_NEXT, "pthread_barrier_init");
   pthread_barrier_wait_ptr = dlsym(RTLD_NEXT, "pthread_barrier_wait");
   pthread_rwlock_init_ptr  = dlsym(RTLD_NEXT, "pthread_rwlock_init");
@@ -61,6 +66,7 @@ mc_load_intercepted_symbol_addresses()
   sem_wait_ptr               = &sem_wait;
   sem_init_ptr               = &sem_init;
   exit_ptr                   = &exit;
+  abort_ptr                  = &abort;
   pthread_barrier_init_ptr   = &pthread_barrier_init;
   pthread_barrier_wait_ptr   = &pthread_barrier_wait;
   pthread_rwlock_init_ptr    = &pthread_rwlock_init;


### PR DESCRIPTION
'assert' calls 'abort' on fail.  Hopefully, McMini can detect both 'exit' and 'assert'.  Hopefully, we can interpose on these, and then report to the scheduler process that we failed, so it can be reported.