### PR TITLE
Add support for reacting to trace errors by intercepting `SIGCHLD`

### DIFF
--- a/include/mcmini/mcmini_private.h
+++ b/include/mcmini/mcmini_private.h
@@ -51,6 +51,19 @@ MC_CTOR void mcmini_main();
  */
 extern MC_THREAD_LOCAL tid_t tid_self;
 
+/*
+ * Identifies the current trace being examined by McMini
+ *
+ * TODO: It would be better to have trace ids in the context
+ * of a single execution of a program. McMini should theoretically be
+ * able to model-check multiple programs in sequence
+ *
+ * NOTE: If we ever parallelized the program this would be highly
+ * unsafe and would need to be atomic
+ */
+extern trid_t traceId;
+extern pid_t trace_pid;
+
 /**
  * @brief A fixed-size array assigning to each possible
  * thread of a McMini trace-process a location that at any given time

--- a/include/mcmini/signals.h
+++ b/include/mcmini/signals.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_MCMINI_SIGNALS_HPP
 #define INCLUDE_MCMINI_SIGNALS_HPP
 
+#include <signal.h>
+
 /**
  * @brief Registers signal handlers for a trace process
  *
@@ -26,5 +28,6 @@ void sigusr2_handler_trace(int sig);
 int install_sighandles_for_scheduler();
 void sigint_handler_scheduler(int sig);
 void sigusr1_handler_scheduler(int sig);
+void sigchld_handler_scheduler(int sig, siginfo_t *, void *);
 
 #endif // INCLUDE_MCMINI_SIGNALS_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "mcmini/mcmini.h"
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #define NUM_READERS 2

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -31,11 +31,6 @@ mc_shared_cv (*trace_sleep_list)[MAX_TOTAL_THREADS_IN_PROGRAM] =
   nullptr;
 sem_t mc_pthread_create_binary_sem;
 
-/*
- * Identifies the trace number of the model checker
- * Note that is we ever parallelized the program
- * this would be highly unsafe and would need to be atomic
- */
 trid_t traceId      = 0;
 trid_t transitionId = 0;
 
@@ -467,7 +462,7 @@ void
 mc_wait_for_trace()
 {
   MC_ASSERT(trace_pid != -1);
-  waitpid(trace_pid, nullptr, 0);
+  waitpid(trace_pid, NULL, 0);
 }
 
 void

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -1,9 +1,10 @@
 #include "mcmini/signals.h"
 #include "mcmini/mcmini_private.h"
 #include <fcntl.h>
-#include <signal.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 int
@@ -31,6 +32,7 @@ install_sighandles_for_trace()
   // These are intended only for the scheduler
   rc |= sigremovehandler(SIGUSR1);
   rc |= sigremovehandler(SIGINT);
+  rc |= sigremovehandler(SIGCHLD);
   rc |= sigsethandler(SIGUSR1, &sigusr1_handler_trace);
   return rc;
 }
@@ -39,7 +41,7 @@ void
 sigusr1_handler_trace(int sig)
 {
   // Sent by the parent to the trace to force the trace to exit
-  _Exit(0);
+  _exit(EXIT_SUCCESS);
 }
 
 int
@@ -47,6 +49,13 @@ install_sighandles_for_scheduler()
 {
   int rc = sigsethandler(SIGUSR1, &sigusr1_handler_scheduler);
   rc |= sigsethandler(SIGINT, &sigint_handler_scheduler);
+
+  struct sigaction action;
+  action.sa_flags     = SA_SIGINFO;
+  action.sa_sigaction = &sigchld_handler_scheduler;
+  sigemptyset(&action.sa_mask);
+  rc |= sigaction(SIGCHLD, &action, NULL);
+
   return rc;
 }
 
@@ -64,4 +73,29 @@ sigint_handler_scheduler(int sig)
   char msg[] = "\nmcmini: interrupted\n";
   write(STDERR_FILENO, msg, sizeof(msg));
   mc_stop_model_checking(EXIT_SUCCESS);
+}
+
+void
+sigchld_handler_scheduler(int sig, siginfo_t *info, void *unused)
+{
+  // This is the normal case: a child exited normally (i.e. was sent a
+  // SIGUSR1 and was *explicitly* killed by the scheduler since we
+  // intercept calls to exit(2)) so this is not an error
+  if (info->si_code == CLD_EXITED) { return; }
+
+  // FIXME: Most of the function calls made below are not async-signal
+  // safe. We need to fix this in the future to improve McMini's
+  // robustness/correctness
+  char msg[512];
+  int len =
+    snprintf(msg, sizeof(msg), "Trace %lu stopped early!\n", traceId);
+  msg[len] = '\0';
+
+  write(STDERR_FILENO, msg, len);
+  fsync(STDERR_FILENO);
+
+  // Write the trace contents out
+  programState->printTransitionStack();
+  programState->printNextTransitions();
+  mc_stop_model_checking(EXIT_FAILURE);
 }


### PR DESCRIPTION
When a trace process exits, unexpectedly or otherwise, a `SIGCHLD` is delivered to the scheduler process. 
To determine the difference between a failed trace process and a trace process exiting because it was sent a `SIGUSR1` by the scheduler, the `siginfo_t` struct passed to the signal handler registered by `sigaction(2)` is inspected for its `sa_code` field to determine if the child exited cleanly (i.e. if `sa_code` equals `CLD_EXITED` according to the man pages).

In the future, since the functions currently called within the signal handler are not async-signal safe, we'll need to set a global `sigatomic_t` value and check it in the appropriate locations instead of exiting directly. Since this involves some nontrivial changes and would require us to keep track of more globals I've gone with this approach for now.