### PR TITLE
Add 'mcmini-gdb' cmd, using gdbinit, etc.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,7 +61,9 @@ mcmini-demo: ${LIBOBJS} libmcrwlock_lib.a
 
 clean:
 	rm -f ${LIBOBJS} mcmini libmcmini.so mcmini-demo libmcrwlock_lib.a
+distclean: clean
+	rm -f Makefile mcmini-gdb
 
-dist: clean
+dist: distclean
 	dir=`basename $$PWD` && cd .. && tar zcvf $$dir.tar.gz ./$$dir
 	dir=`basename $$PWD` && ls -l ../$$dir.tar.gz

--- a/configure
+++ b/configure
@@ -651,6 +651,7 @@ ac_includes_default="\
 ac_header_c_list=
 ac_func_c_list=
 ac_subst_vars='LTLIBOBJS
+PWD
 LIBOBJS
 host_os
 host_vendor
@@ -5063,7 +5064,11 @@ then :
 fi
 
 
+
+
 ac_config_files="$ac_config_files Makefile"
+
+ac_config_files="$ac_config_files mcmini-gdb"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5766,6 +5771,7 @@ for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "mcmini-gdb") CONFIG_FILES="$CONFIG_FILES mcmini-gdb" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -6179,6 +6185,11 @@ which seems to be undefined.  Please make sure it is defined" >&2;}
 
   esac
 
+
+  case $ac_file$ac_mode in
+    "mcmini-gdb":F) chmod a+x mcmini-gdb ;;
+
+  esac
 done # for ac_tag
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -29,5 +29,8 @@ AC_FUNC_MALLOC
 AC_FUNC_MMAP
 AC_CHECK_FUNCS([atexit ftruncate setenv strtoul])
 
+AC_SUBST(PWD)
+
 AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([mcmini-gdb], [chmod a+x mcmini-gdb])
 AC_OUTPUT

--- a/gdbinit
+++ b/gdbinit
@@ -25,7 +25,13 @@ set schedule-multiple on
 ## Newer GDBs can use "tui disable" to undo "layout src"
 ## We should test if "tui disable" works, and then use it.
 
-source gdbinit_commands.py
+# source [$MCMINI_ROOT/]gdbinit_commands.py"
+python import os
+python DIR = ""
+python if os.environ.get("MCMINI_ROOT"): DIR = os.environ["MCMINI_ROOT"]+"/"
+python if DIR: gdb.execute("dir " + DIR)
+python print("source " + DIR + "gdbinit_commands.py")
+python gdb.execute("source " + DIR + "gdbinit_commands.py")
 
 # Stop at main in scheduler.
 # Later, whenever we fork into target process, stop at main.

--- a/mcmini-gdb.in
+++ b/mcmini-gdb.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export MCMINI_ROOT=@PWD@
+if test "$1" == ""; then
+  echo "USAGE:  $0 [OPTIONS] TARGET_FILE"
+  $MCMINI_ROOT/mcmini
+  exit 1
+fi
+
+gdb -x $MCMINI_ROOT/gdbinit --args $MCMINI_ROOT/mcmini $*


### PR DESCRIPTION
`mcmini-gdb TARGET_PROGRAM` now works.  It's the equivalent of:
`gdb -x gdbinit --args TARGET_PROGRAM`

It also works if you `./configure` and then copy `mcmini-gdb` to another directory to use it.