### PR TITLE
make distclean: remove config.{log,status}

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,7 +62,7 @@ mcmini-demo: ${LIBOBJS} libmcrwlock_lib.a
 clean:
 	rm -f ${LIBOBJS} mcmini libmcmini.so mcmini-demo libmcrwlock_lib.a
 distclean: clean
-	rm -f Makefile mcmini-gdb
+	rm -f Makefile mcmini-gdb config.log config.status
 
 dist: distclean
 	dir=`basename $$PWD` && cd .. && tar zcvf $$dir.tar.gz ./$$dir


### PR DESCRIPTION
Tiny change:  The `config.log` and `config.status` of the developer should not be passed on to the user when creating `mcmini.tar.gz `via `make dist`.