### PR TITLE
mcmini <FLAGS>:  Use more meaningful names

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -8,9 +8,6 @@ set pagination off
 set detach-on-fork off
 set print pretty
 set print address off
-# Stop if about to exit:
-break _exit
-set variable $bpnum_exit = $bpnum
 # In McMini, parent sends SIGUSR1 to child on exit.
 handle SIGUSR1 nostop noprint pass
 handle SIGUSR2 nostop noprint pass
@@ -40,6 +37,12 @@ run
 
 tbreak execvp
 continue
+
+python if (not gdb.selected_inferior().threads()): sys.exit(1)
+
+# Stop if about to exit:
+break _exit
+set variable $bpnum_exit = $bpnum
 
 tbreak 'mcmini_main()'
 continue

--- a/mcmini-gdb.in
+++ b/mcmini-gdb.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export MCMINI_ROOT=@PWD@
-if test "$1" == ""; then
+if test "$1" = ""; then
   echo "USAGE:  $0 [OPTIONS] TARGET_FILE"
   $MCMINI_ROOT/mcmini
   exit 1

--- a/src/MCState.cpp
+++ b/src/MCState.cpp
@@ -250,13 +250,19 @@ bool
 MCState::isInDeadlock() const
 {
   /*
-   * We artificially restrict deadlock reports to those in which the
-   * total thread depth is at most the total allowed by the program
+   * FIXME:  This 'if' statement is being commented out.
+   *         In the future, we could consider a new flag, --max-total-depth
+   *         So, the code here is kept, to be re-purposed.
    */
-  if (this->totalThreadExecutionDepth() >
-      this->configuration.maxThreadExecutionDepth) {
-    return false;
-  }
+  /*
+   * We artificially restrict deadlock reports to those in which the
+   * total thread depth is at most the total allowed by the program.
+   *
+   * if (this->totalThreadExecutionDepth() >
+   *     this->configuration.maxThreadExecutionDepth) {
+   *   return false;
+   * }
+   */
 
   const auto numThreads = this->getNumProgramThreads();
   for (tid_t tid = 0; tid < numThreads; tid++) {

--- a/src/launch.c
+++ b/src/launch.c
@@ -19,9 +19,11 @@ main(int argc, char *argv[])
 
   // TODO: Use argp.h instead (more options, better descriptions, etc)
   while (cur_arg[0] != NULL && cur_arg[0][0] == '-') {
-    if (strcmp(cur_arg[0], "--max-trace-depth") == 0 ||
+    if (strcmp(cur_arg[0], "--max-depth-per-thread") == 0 ||
         strcmp(cur_arg[0], "-m") == 0) {
-      // FIXME: "env_max_thread_depth":Just use "MCMINI_MAX_THREAD_DEPTH" below.
+      // FIXME: "env_max_thread_depth":
+      //           Just use "MCMINI_MAX_DEPTH_PER_THREAD" below, everywhere.
+      //           There's no need to add a '#define' to hide the env var name.
       setenv(ENV_MAX_THREAD_DEPTH, cur_arg[1], 1);
       cur_arg += 2;
     }
@@ -32,6 +34,7 @@ main(int argc, char *argv[])
     else if (strcmp(cur_arg[0], "--debug-at-trace") == 0 ||
              strcmp(cur_arg[0], "-d") == 0) {
       // FIXME: "env_debug_at_trace": Just use "MCMINI_DEBUG_AT_TRACE" below.
+      //        There's no need to add a '#define' to hide the env var name.
       setenv(ENV_DEBUG_AT_TRACE, cur_arg[1], 1);
       cur_arg += 2;
     }
@@ -41,11 +44,17 @@ main(int argc, char *argv[])
     }
     else if (strcmp(cur_arg[0], "--verbose") == 0 ||
              strcmp(cur_arg[0], "-v") == 0) {
+      // FIXME: ENV_VERBOSE: Just use "MCMINI_VERBOSE" below and everywhere.
+      //        There's no need to add a '#define' to hide the env var name.
       setenv(ENV_VERBOSE, "1", 1);
       cur_arg++;
     }
     else if (strcmp(cur_arg[0], "--first-deadlock") == 0 ||
-             strcmp(cur_arg[0], "-first") == 0) {
+             strcmp(cur_arg[0], "--first") == 0 ||
+             strcmp(cur_arg[0], "-f") == 0) {
+      // FIXME: ENV_STOP_AT_FIRST_DEADLOCK: Just use "MCMINI_FIRST_DEADLOCK"
+      //           below and everywhere.
+      //        There's no need to add a '#define' to hide the env var name.
       setenv(ENV_STOP_AT_FIRST_DEADLOCK, "1", 1);
       cur_arg++;
     }
@@ -54,16 +63,16 @@ main(int argc, char *argv[])
       setenv(ENV_CHECK_FORWARD_PROGRESS, "1", 1);
       cur_arg++;
     }
-    else if (strcmp(cur_arg[0], "--print") == 0) {
+    else if (strcmp(cur_arg[0], "--print-at-trace") == 0) {
       setenv(ENV_PRINT_AT_TRACE, cur_arg[1], 1);
       cur_arg += 2;
     }
     else if (strcmp(cur_arg[0], "--help") == 0 ||
              strcmp(cur_arg[0], "-h") == 0) {
       fprintf(stderr,
-              "Usage: mcmini [--max-trace-depth|-m <num>] "
+              "Usage: mcmini [--max-depth-per-thread|-m <num>] "
               "[--debug-at-trace|-d <num>]\n"
-              "[--first-deadlock|-first] [--print]\n"
+              "[--first-deadlock|-first] [--print-at-trace]\n"
               "[--verbose|-v] [--help|-h] target_executable\n");
       exit(1);
     }


### PR DESCRIPTION
 * The convention is '--first' or '-f'.  A single '-' is used only for a single-character flag.
 * This also fixes a bug in 'mcmini-gdb.in'.
 * This also fixes gdbinit in the case of no such target_executable.