### PR TITLE
gdb --args gdbinit mcmini: Detect if -g3 was used

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,7 +17,10 @@ LIBOBJS4=src/transitions/barrier/MCBarrierEnqueue.o src/transitions/barrier/MCBa
 LIBOBJS=${LIBOBJS1} ${LIBOBJS2} ${LIBOBJS3} ${LIBOBJS4} \
        	src/mc_shared_sem.o src/MCCommon.o src/main.o
 
-all: mcmini libmcmini.so mcmini-demo
+all: mcmini libmcmini.so mcmini-demo NO-GDB-G3
+
+NO-GDB-G3:
+	touch $@
 
 # If McMini was already built, first do:  'make clean'
 debug:
@@ -61,6 +64,7 @@ mcmini-demo: ${LIBOBJS} libmcrwlock_lib.a
 
 clean:
 	rm -f ${LIBOBJS} mcmini libmcmini.so mcmini-demo libmcrwlock_lib.a
+	rm -f NO-GDB-G3
 distclean: clean
 	rm -f Makefile mcmini-gdb config.log config.status
 

--- a/gdbinit
+++ b/gdbinit
@@ -23,10 +23,14 @@ set schedule-multiple on
 ## We should test if "tui disable" works, and then use it.
 
 # source [$MCMINI_ROOT/]gdbinit_commands.py"
-python import os
+python import os, sys
 python DIR = ""
 python if os.environ.get("MCMINI_ROOT"): DIR = os.environ["MCMINI_ROOT"]+"/"
 python if DIR: gdb.execute("dir " + DIR)
+python if os.path.isfile("NO-GDB-G3"): \
+  print("\n*** Not compiled with -g3.  Please call:\n" + \
+        "***                             make clean && make -j9 debug"); \
+  sys.exit(1)
 python print("source " + DIR + "gdbinit_commands.py")
 python gdb.execute("source " + DIR + "gdbinit_commands.py")
 


### PR DESCRIPTION
When use `gdb --args gdbinit mcmini a.out` or `mcmini-gdb a.out`, check if file `NO-GDB-G3` exists (meaning that mcmini was not compiled with '-g3 -O0'.
If that happens, then refuse to execute, and propose that the user does:  `make clean && make -9 debug`.