### PR TITLE
Stop McMini test in one hour unless '--long-test'

### DIFF
--- a/include/mcmini/MCEnv.h
+++ b/include/mcmini/MCEnv.h
@@ -6,6 +6,7 @@
 #define ENV_PRINT_AT_TRACE         "env_print_at_trace"
 #define ENV_STOP_AT_FIRST_DEADLOCK "env_stop_at_first_deadlock"
 #define ENV_CHECK_FORWARD_PROGRESS "env_check_forward_progress"
+#define ENV_LONG_TEST              "MCMINI_LONG_TEST"
 #define ENV_VERBOSE                "VERBOSE"
 
 #endif // MC_MCENV_H

--- a/src/launch.c
+++ b/src/launch.c
@@ -63,6 +63,10 @@ main(int argc, char *argv[])
       setenv(ENV_CHECK_FORWARD_PROGRESS, "1", 1);
       cur_arg++;
     }
+    else if (strcmp(cur_arg[0], "--long-test") == 0) {
+      setenv(ENV_LONG_TEST, "1", 1);
+      cur_arg++;
+    }
     else if (strcmp(cur_arg[0], "--print-at-trace") == 0) {
       setenv(ENV_PRINT_AT_TRACE, cur_arg[1], 1);
       cur_arg += 2;

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -67,9 +67,22 @@ const size_t shmAllocationSize =
 /* Program state */
 MCDeferred<MCState> programState;
 
+void alarm_handler(int sig) {
+  if (sig == SIGALRM) {
+    fprintf(stderr, "\n *** mcmini exiting after one hour.  To avoid, this,\n"
+             " *** Use flag '--long-test' or  MCMINI_LONG_TEXT env. var.\n\n");
+    _exit(1);  // Note:  McMini wraps 'exit()'.  So, we use '_exit()'.
+  }
+}
+
+// FIXME:  Replace MC_CTOR by ...constructor..., to find it when using 'grep'
 MC_CTOR void
 mcmini_main()
 {
+  if (getenv(ENV_LONG_TEST) == NULL) {
+    alarm(3600); // one hour
+    signal(SIGALRM , alarm_handler);
+  }
   mc_load_intercepted_symbol_addresses();
   mc_create_global_state_object();
   mc_initialize_shared_memory_globals();


### PR DESCRIPTION
The flag `--long-test` and the environment variable `MCMINI_LONG_TEST` will stop McMini from canceling a job after one hour.  Otherwise, McMini's call to `alarm(3600)` will cause the handler to print a message and exit after one hour.

This is especially important when running test with runaway jobs, or when using this in classroom assignments. 