### PR TITLE
Simplify core DPOR logic

### DIFF
--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -360,7 +360,7 @@ class gotoTraceCmd(gdb.Command):
     gdb.execute("set detach-on-fork on")
     # Optional argument:  internal=False ## FIXME: Change to True when ready.
     # FIXME:  If fifth arg here, it says only 4 args.  But 5 args work above.
-    bkpt = gdb.Breakpoint("mc_search_next_dpor_branch_with_initial_thread" +
+    bkpt = gdb.Breakpoint("mc_search_dpor_branch_with_thread" +
                             "(unsigned long)",
                           gdb.BP_BREAKPOINT, gdb.WP_WRITE, True)
     bkpt.silent = True

--- a/include/mcmini/MCConstants.h
+++ b/include/mcmini/MCConstants.h
@@ -25,14 +25,6 @@ typedef uint64_t trid_t;
 #define FORK_IS_CHILD_PID(pid)    ((pid) == 0)
 #define FORK_IS_PARENT_PID(pid)   (!(FORK_IS_CHILD_PID(pid)))
 
-#define MC_PROGRAM_TYPE           bool
-#define MC_SCHEDULER              (false)
-#define MC_TARGET_PROGRAM         (true)
-#define MC_IS_SCHEDULER(expr) \
-  (static_cast<bool>(expr) == MC_SCHEDULER)
-#define MC_IS_TARGET_PROGRAM(expr) \
-  (static_cast<bool>(expr) == MC_TARGET_PROGRAM)
-
 #ifdef MC_SHARED_LIBRARY
 #define MC_CONSTRUCTOR __attribute__((constructor))
 #else

--- a/include/mcmini/MCState.h
+++ b/include/mcmini/MCState.h
@@ -24,6 +24,14 @@ typedef MCTransition *(*MCSharedMemoryHandler)(
 #include <unordered_set>
 #include <vector>
 
+
+/* This is returned by getDeepestDPORBranchPoint() if this is the
+ * first (origina) branch.  mc_do_model_checking() uses this to detect
+ * when we have backtracked to before the beginning of theoriginal branch
+ * (i.e., when mc_do_model_checking() is finished.
+ */
+#define FIRST_BRANCH (-1)
+
 /**
  * @brief A reflection of the state of the program under which McMini
  * is model checking
@@ -417,12 +425,11 @@ public:
    * @brief Retrieves the index of the state closest to the top of the
    * state stack that contains at least one backtrack point
    *
-   * @return MCOptional<int>::some() containing the index into the
-   * state stack containing an MCStateStackItem with at least one
-   * thread to backtrack on, or MCOptional<int>::nil() if no such
+   * @return the index into the state stack containing an MCStateStackItem
+   * with at least one thread to backtrack on, or FIRST_BRANCH if no such
    * state exists
    */
-  MCOptional<int> getDeepestDPORBranchPoint();
+  int getDeepestDPORBranchPoint();
 
   /**
    * @brief Retrieves the state (represented by the item in the state

--- a/include/mcmini/mcmini_private.h
+++ b/include/mcmini/mcmini_private.h
@@ -252,14 +252,6 @@ void mc_run_initial_trace();
  * @param leadThread the thread whose execution should be followed
  * from the current program state to continue the DPOR, depth-first
  * search.
- */
-void
-mc_search_next_dpor_branch_with_initial_thread(
-  const tid_t leadThread);
-
-/**
- * @brief Begins searching a new branch in the state space starting
- * with "leadThread" executing from the current program state
  *
  * This method makes two assumptions:
  *   1. There is a trace process forked and waiting for the scheduler
@@ -271,17 +263,21 @@ mc_search_next_dpor_branch_with_initial_thread(
  *
  * If either assumption is invalid, McMini will abort the backtracking
  * session; for otherwise McMini would be stuck in a deadlock.
- *
- * @param leadThread the thread whose execution should be followed
- * from the current program state to continue the DPOR, depth-first
- * search.
  */
 void
-mc_search_dpor_branch_with_initial_thread(const tid_t leadThread);
+mc_search_dpor_branch_with_thread(const tid_t leadThread);
 
 /**
- * @brief Forks a new trace process whose execution begins immediately
- * after this function
+ * This method makes two assumptions:
+ *   1. There is a trace process forked and waiting for the scheduler
+ *      to send requests for threads to execute through the mailbox
+ *      (see the global variables residing in shared memory declared
+ *      at the start of the header file).
+ *   2. The thread that is about to execute is enabled in the given
+ *      state.
+ *
+ * If either assumption is invalid, McMini will abort the backtracking
+ * session; for otherwise McMini would be stuck in a deadlock.
  *
  * When a new trace process is created, its execution begins inside
  * the control flow of the scheduler that spawned it. As the trace is
@@ -317,7 +313,7 @@ void mc_fork_new_trace_at_main();
  * scheduler at the particular point in the past (i.e. backtracking
  * point)
  */
-void mc_fork_new_trace_at_current_state();
+void mc_fork_next_trace_at_current_state();
 
 /**
  * @brief Unblocks the thread corresponding to _tid_ in the current
@@ -422,7 +418,7 @@ void mc_report_undefined_behavior(const char *);
  * an arbitrary number of times. By default, the function will not
  * cause any re-executions.
  */
-void mc_rerun_current_trace_as_needed();
+void mc_run_next_trace_for_debugger();
 
 MCStateConfiguration get_config_for_execution_environment();
 

--- a/include/mcmini/mcmini_private.h
+++ b/include/mcmini/mcmini_private.h
@@ -225,13 +225,8 @@ void mc_prepare_to_model_check_new_program();
  *
  * After the initialization phase, this function is invoked to perform
  * the actual model-checking using DPOR of the test program
- *
- * @return MC_PROGRAM_TYPE An identifier for which program exited the
- * call to the function. This gives the information callers need to
- * allow fork()-ed trace process to escape into the target program for
- * testing
  */
-MC_PROGRAM_TYPE mc_do_model_checking();
+void mc_do_model_checking();
 
 /**
  * @brief Perform the first (depth-first) search of the state space
@@ -247,13 +242,8 @@ MC_PROGRAM_TYPE mc_do_model_checking();
  * any other trace. The primary difference resides in the fact that
  * the state is set up to have only a single thread -- the main thread
  * in particular -- waiting to execute the "thread start" transition.
- *
- * @return MC_PROGRAM_TYPE An identifier for which program exited the
- * call to the function. This gives the information callers need to
- * allow a fork()-ed trace process to escape into the target program
- * for testing
  */
-MC_PROGRAM_TYPE mc_run_initial_trace();
+void mc_run_initial_trace();
 
 /**
  * @brief Begins searching a new branch in the state space starting
@@ -262,13 +252,8 @@ MC_PROGRAM_TYPE mc_run_initial_trace();
  * @param leadThread the thread whose execution should be followed
  * from the current program state to continue the DPOR, depth-first
  * search.
- *
- * @return The process identifier. The caller should allow
- * the process to escape into the target program as quickly
- * as possible to allow the scheduler to begin controlling its
- * execution
  */
-MC_PROGRAM_TYPE
+void
 mc_search_next_dpor_branch_with_initial_thread(
   const tid_t leadThread);
 
@@ -294,13 +279,6 @@ mc_search_next_dpor_branch_with_initial_thread(
 void
 mc_search_dpor_branch_with_initial_thread(const tid_t leadThread);
 
-/* Source program management */
-/*
- * FIXME: We should have a mcmini::ProcessVendor() here which manages
- * the lifetimes of processes. This may help simplify the logic and
- * will remove MC_PROGRAM_TYPE in favor of an enum of the same name
- */
-
 /**
  * @brief Forks a new trace process whose execution begins immediately
  * after this function
@@ -314,13 +292,8 @@ mc_search_dpor_branch_with_initial_thread(const tid_t leadThread);
  * modifications to all variables (not explicitly mapped into shared
  * memory) are isolated to the scheduler and each newly-spawned
  * trace
- *
- * @return The process identifier. The caller should allow
- * the process to escape into the target program as quickly
- * as possible to allow the scheduler to begin controlling its
- * execution
  */
-MC_PROGRAM_TYPE mc_fork_new_trace();
+void mc_fork_new_trace();
 
 /**
  * @brief Forks a new trace process whose execution is blocked until
@@ -330,12 +303,8 @@ MC_PROGRAM_TYPE mc_fork_new_trace();
  * main routine of the target program. The newly created trace will be
  * blocked waiting to enter the main function until the scheduler
  * later allows the thread to exit
- *
- * @return The process identifier. The caller should allow
- * the process to escape into the target program as quickly
- * as possible
  */
-MC_PROGRAM_TYPE mc_fork_new_trace_at_main();
+void mc_fork_new_trace_at_main();
 
 /**
  * @brief Forks a new trace process whose run-time state reflects that
@@ -347,12 +316,8 @@ MC_PROGRAM_TYPE mc_fork_new_trace_at_main();
  * (i.e. memory and threads) matches that originally recorded by the
  * scheduler at the particular point in the past (i.e. backtracking
  * point)
- *
- * @return The process identifier. The caller should allow
- * the process to escape into the target program as quickly
- * as possible
  */
-MC_PROGRAM_TYPE mc_fork_new_trace_at_current_state();
+void mc_fork_new_trace_at_current_state();
 
 /**
  * @brief Unblocks the thread corresponding to _tid_ in the current
@@ -456,12 +421,8 @@ void mc_report_undefined_behavior(const char *);
  * When this method is invoked, the current trace can be re-executed
  * an arbitrary number of times. By default, the function will not
  * cause any re-executions.
- *
- * @return The process identifier. The caller should allow
- * the process to escape into the target program as quickly
- * as possible
  */
-MC_PROGRAM_TYPE mc_rerun_current_trace_as_needed();
+void mc_rerun_current_trace_as_needed();
 
 MCStateConfiguration get_config_for_execution_environment();
 

--- a/src/MCState.cpp
+++ b/src/MCState.cpp
@@ -200,14 +200,14 @@ MCState::getStateStackTop() const
   return this->getStateItemAtIndex(this->stateStackTop);
 }
 
-MCOptional<int>
+int
 MCState::getDeepestDPORBranchPoint()
 {
   for (int j = this->stateStackTop; j >= 0; j--) {
     const auto &s = this->getStateItemAtIndex(j);
-    if (s.hasThreadsToBacktrackOn()) return MCOptional<int>::some(j);
+    if (s.hasThreadsToBacktrackOn()) return j;
   }
-  return MCOptional<int>::nil();
+  return FIRST_BRANCH;
 }
 
 const MCTransition *

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -230,15 +230,38 @@ mc_prepare_to_model_check_new_program()
                                            initialTransition);
 }
 
+// nextBranchPoint is an out parameter.
 void
-mc_run_initial_trace()
+mc_explore_branch(MCOptional<int> *nextBranchPointPtr)
 {
-  mc_fork_new_trace_at_main();
+  tid_t backtrackThread;
 
-  mc_search_dpor_branch_with_initial_thread(TID_MAIN_THREAD);
+  if (nextBranchPointPtr == nullptr /* initial branch */) {
+    mc_fork_new_trace_at_main();
+    backtrackThread = TID_MAIN_THREAD;
+  } else { // else next branch
+    const int bp = nextBranchPointPtr->unwrapped();
+    auto *sNext = &(programState->getStateItemAtIndex(bp));
+    backtrackThread = sNext->popThreadToBacktrackOn();
+
+    // Prepare the scheduler's model of the next trace
+    programState->reflectStateAtTransitionIndex(bp - 1);
+  }
+
+  if (nextBranchPointPtr == nullptr /* initial branch */) {
+    mc_search_dpor_branch_with_initial_thread(TID_MAIN_THREAD);
+  } else {
+    // Search the branch that DPOR dictated needed to be searched
+    mc_search_next_dpor_branch_with_initial_thread(backtrackThread);
+  }
+
   mc_exit_with_trace_if_necessary(traceId);
   mc_rerun_current_trace_as_needed();
+
   traceId++;
+  if (nextBranchPointPtr != nullptr) { // if this is not the initial branch
+    *nextBranchPointPtr = programState->getDeepestDPORBranchPoint();
+  }
 }
 
 void
@@ -246,12 +269,17 @@ mc_do_model_checking()
 {
   mc_prepare_to_model_check_new_program();
 
-  mc_run_initial_trace();
+  mc_explore_branch(nullptr); // nullptr means this is the initial branch
 
   MCOptional<int> nextBranchPoint =
     programState->getDeepestDPORBranchPoint();
 
   while (nextBranchPoint.hasValue()) {
+    MCOptional<int> *nextBranchPointPtr = &nextBranchPoint;
+    mc_explore_branch(nextBranchPointPtr);
+
+#if 0
+    // FIXME:  Delete this '#if 0' when the code works.
     const int bp = nextBranchPoint.unwrapped();
     auto &sNext  = programState->getStateItemAtIndex(bp);
     const tid_t backtrackThread = sNext.popThreadToBacktrackOn();
@@ -267,6 +295,7 @@ mc_do_model_checking()
 
     traceId++;
     nextBranchPoint = programState->getDeepestDPORBranchPoint();
+#endif
   }
 }
 

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -73,7 +73,7 @@ static void printResults() {
  * into the debugger, or perhaps make it a local variable.
  * Effectively, we should make it more difficult to set this value
  * since it affects the behavior of a rather important function for
- * state regeneration (viz. mc_fork_new_trace_at_current_state())
+ * state regeneration (viz. mc_fork_next_trace_at_current_state())
  */
 bool rerunCurrentTraceForDebugger = false;
 
@@ -237,7 +237,7 @@ mc_explore_branch(MCOptional<int> *nextBranchPointPtr)
   tid_t backtrackThread;
 
   if (nextBranchPointPtr == nullptr /* initial branch */) {
-    mc_fork_new_trace_at_main();
+    mc_fork_new_trace();
     backtrackThread = TID_MAIN_THREAD;
   } else { // else next branch
     const int bp = nextBranchPointPtr->unwrapped();
@@ -246,17 +246,13 @@ mc_explore_branch(MCOptional<int> *nextBranchPointPtr)
 
     // Prepare the scheduler's model of the next trace
     programState->reflectStateAtTransitionIndex(bp - 1);
+
+    mc_fork_next_trace_at_current_state();
   }
 
-  if (nextBranchPointPtr == nullptr /* initial branch */) {
-    mc_search_dpor_branch_with_initial_thread(TID_MAIN_THREAD);
-  } else {
-    // Search the branch that DPOR dictated needed to be searched
-    mc_search_next_dpor_branch_with_initial_thread(backtrackThread);
-  }
-
+  mc_search_dpor_branch_with_thread(backtrackThread);
   mc_exit_with_trace_if_necessary(traceId);
-  mc_rerun_current_trace_as_needed();
+  mc_run_next_trace_for_debugger();
 
   traceId++;
   if (nextBranchPointPtr != nullptr) { // if this is not the initial branch
@@ -271,31 +267,11 @@ mc_do_model_checking()
 
   mc_explore_branch(nullptr); // nullptr means this is the initial branch
 
-  MCOptional<int> nextBranchPoint =
-    programState->getDeepestDPORBranchPoint();
+  MCOptional<int> nextBranchPoint = programState->getDeepestDPORBranchPoint();
 
   while (nextBranchPoint.hasValue()) {
     MCOptional<int> *nextBranchPointPtr = &nextBranchPoint;
     mc_explore_branch(nextBranchPointPtr);
-
-#if 0
-    // FIXME:  Delete this '#if 0' when the code works.
-    const int bp = nextBranchPoint.unwrapped();
-    auto &sNext  = programState->getStateItemAtIndex(bp);
-    const tid_t backtrackThread = sNext.popThreadToBacktrackOn();
-
-    // Prepare the scheduler's model of the next trace
-    programState->reflectStateAtTransitionIndex(bp - 1);
-
-    // Search the next branch that DPOR dictated needed to be searched
-    mc_search_next_dpor_branch_with_initial_thread(backtrackThread);
-
-    mc_exit_with_trace_if_necessary(traceId);
-    mc_rerun_current_trace_as_needed();
-
-    traceId++;
-    nextBranchPoint = programState->getDeepestDPORBranchPoint();
-#endif
   }
 }
 
@@ -464,10 +440,10 @@ mc_fork_new_trace()
 }
 
 void
-mc_fork_new_trace_at_current_state()
+mc_fork_next_trace_at_current_state()
 {
   mc_reset_cv_locks();
-  mc_fork_new_trace_at_main();
+  mc_fork_new_trace();
 
   const int tStackHeight = programState->getTransitionStackSize();
 
@@ -486,12 +462,6 @@ mc_fork_new_trace_at_current_state()
       programState->getThreadRunningTransitionAtIndex(i);
     mc_run_thread_to_next_visible_operation(nextTid);
   }
-}
-
-void
-mc_fork_new_trace_at_main()
-{
-  mc_fork_new_trace();
 }
 
 void
@@ -531,14 +501,14 @@ mc_trace_panic()
 }
 
 void
-mc_search_dpor_branch_with_initial_thread(const tid_t leadingThread)
+mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
 {
   uint64_t depth = programState->getTransitionStackSize();
   const MCTransition &initialTransition =
-    programState->getNextTransitionForThread(leadingThread);
-  const MCTransition *t_next = &initialTransition;
+    programState->getNextTransitionForThread(backtrackThread);
+  const MCTransition *nextTransition = &initialTransition;
 
-  // TODO: Assert whether or not t_next is enabled
+  // TODO: Assert whether or not nextTransition is enabled
   // TODO: Assert whether a trace process exists at this point
 
   do {
@@ -557,11 +527,11 @@ mc_search_dpor_branch_with_initial_thread(const tid_t leadingThread)
     depth++;
     transitionId++;
 
-    const tid_t tid = t_next->getThreadId();
+    const tid_t tid = nextTransition->getThreadId();
     mc_run_thread_to_next_visible_operation(tid);
 
     programState->simulateRunningTransition(
-      *t_next, shmTransitionTypeInfo, shmTransitionData);
+      *nextTransition, shmTransitionTypeInfo, shmTransitionData);
     programState->dynamicallyUpdateBacktrackSets();
 
     /* Check for data races */
@@ -577,8 +547,8 @@ mc_search_dpor_branch_with_initial_thread(const tid_t leadingThread)
       }
     }
 
-    t_next = programState->getFirstEnabledTransition();
-  } while (t_next != nullptr);
+    nextTransition = programState->getFirstEnabledTransition();
+  } while (nextTransition != nullptr);
 
   const bool hasDeadlock        = programState->isInDeadlock();
   const bool programHasNoErrors = !hasDeadlock;
@@ -609,14 +579,6 @@ mc_search_dpor_branch_with_initial_thread(const tid_t leadingThread)
   }
 
   mc_terminate_trace();
-}
-
-void
-mc_search_next_dpor_branch_with_initial_thread(
-  const tid_t leadingThread)
-{
-  mc_fork_new_trace_at_current_state();
-  mc_search_dpor_branch_with_initial_thread(leadingThread);
 }
 
 tid_t
@@ -666,7 +628,7 @@ mc_exit_with_trace_if_necessary(trid_t trid)
 }
 
 void
-mc_rerun_current_trace_as_needed()
+mc_run_next_trace_for_debugger()
 {
   while (rerunCurrentTraceForDebugger) {
     // McMini will only re-execute a trace
@@ -674,7 +636,7 @@ mc_rerun_current_trace_as_needed()
     // McMini to execute more than once, it
     // could reset this value to `true`.
     rerunCurrentTraceForDebugger = false;
-    mc_fork_new_trace_at_current_state();
+    mc_fork_next_trace_at_current_state();
     mc_terminate_trace();
   }
 }


### PR DESCRIPTION
* Remove PROGRAM_TYPE, MC_TARGET, MC_SCHEDULER, etc.
  This is the first commit of several.  The goal is to simplify the core DPOR logic.
* Simplify core DPOR logic using mc_explore_branch()
  This defines mc_explore_branch() to replace both mc_initial_trace() and the inline code after `while (nextBranchPoint->hasValue())`
* Minor renaming and removing unneeded functions