### PR TITLE
Allow '-v' and '-v -v'; reprint failures at end

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,9 @@
 ROOT=$$PWD/
 
-CC=gcc
-CXX=g++
+CC=@CC@
+CXX=@CXX@
+CFLAGS=@CFLAGS@
+CXXFLAGS=@CXXFLAGS@
 # The defines needed for MCSharedLibraryWrappers.c (and maybe other things???).
 override CFLAGS+=-I${ROOT}/include -fPIC -DMC_SHARED_LIBRARY=1 -Dmcmini_checker_EXPORTS
 override CXXFLAGS=${CFLAGS} -std=gnu++11

--- a/configure
+++ b/configure
@@ -651,6 +651,7 @@ ac_includes_default="\
 ac_header_c_list=
 ac_func_c_list=
 ac_subst_vars='LTLIBOBJS
+DEBUG
 PWD
 LIBOBJS
 host_os
@@ -713,6 +714,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_debug
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1342,6 +1344,13 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of McMini 1.0:";;
    esac
   cat <<\_ACEOF
+
+Optional Features:
+  --disable-option-checking  ignore unrecognized --enable/--with options
+  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
+  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-debug          Use debugging flags "-Wall -g3 -O0" (default is -g
+                          -O0)
 
 Some influential environment variables:
   CXX         C++ compiler command
@@ -5065,6 +5074,29 @@ fi
 
 
 
+
+# Check whether --enable-debug was given.
+if test ${enable_debug+y}
+then :
+  enableval=$enable_debug; use_debug=$enableval
+else $as_nop
+  use_debug=no
+fi
+
+
+if test "$use_debug" = "yes"; then
+  DEBUG=yes
+
+
+printf "%s\n" "#define DEBUG 1" >>confdefs.h
+
+  CFLAGS="$CFLAGS -Wall -g3 -O0 -DDEBUG"
+  CPPFLAGS="$CPPFLAGS -Wall -g3 -O0 -DDEBUG"
+  CXXFLAGS="$CXXFLAGS -Wall -g3 -O0 -DDEBUG"
+else
+  DEBUG=no
+
+fi
 
 ac_config_files="$ac_config_files Makefile"
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,23 @@ AC_CHECK_FUNCS([atexit ftruncate setenv strtoul])
 
 AC_SUBST(PWD)
 
+AC_ARG_ENABLE([debug],
+            [AS_HELP_STRING([--enable-debug],
+                            [Use debugging flags "-Wall -g3 -O0"
+                             (default is -g -O0)])],
+            [use_debug=$enableval],
+            [use_debug=no])
+
+if test "$use_debug" = "yes"; then
+  AC_SUBST([DEBUG], [yes])
+  AC_DEFINE([DEBUG],[1],[Use debugging flags "-Wall -g3 -O0"])
+  CFLAGS="$CFLAGS -Wall -g3 -O0 -DDEBUG"
+  CPPFLAGS="$CPPFLAGS -Wall -g3 -O0 -DDEBUG"
+  CXXFLAGS="$CXXFLAGS -Wall -g3 -O0 -DDEBUG"
+else
+  AC_SUBST([DEBUG], [no])
+fi
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([mcmini-gdb], [chmod a+x mcmini-gdb])
 AC_OUTPUT

--- a/include/mcmini/MCState.h
+++ b/include/mcmini/MCState.h
@@ -559,6 +559,7 @@ public:
   void reflectStateAtTransitionIndex(uint32_t tIndex);
 
   // TODO: De-couple priting from the state stack + transitions
+  void printThreadSchedule() const;
   void printTransitionStack() const;
   void printNextTransitions() const;
 };

--- a/src/MCState.cpp
+++ b/src/MCState.cpp
@@ -867,17 +867,24 @@ MCState::registerVisibleObjectWithSystemIdentity(
 }
 
 void
+MCState::printThreadSchedule() const
+{
+  for (int i = 0; i <= this->transitionStackTop; i++) {
+    const tid_t tid = this->getTransitionAtIndex(i).getThreadId();
+    printf("%lu, ", tid);
+  }
+  printf("\n");
+}
+
+void
 MCState::printTransitionStack() const
 {
   printf("THREAD BACKTRACE\n");
   for (int i = 0; i <= this->transitionStackTop; i++) {
     this->getTransitionAtIndex(i).print();
   }
-  for (int i = 0; i <= this->transitionStackTop; i++) {
-    const tid_t tid = this->getTransitionAtIndex(i).getThreadId();
-    printf("%lu, ", tid);
-  }
-  printf("\nEND\n");
+  MCState::printThreadSchedule();
+  printf("END\n");
   mcflush();
 }
 

--- a/src/launch.c
+++ b/src/launch.c
@@ -39,7 +39,11 @@ main(int argc, char *argv[])
     }
     else if (strcmp(cur_arg[0], "--verbose") == 0 ||
              strcmp(cur_arg[0], "-v") == 0) {
-      setenv(ENV_VERBOSE, "1", 1);
+      if (getenv(ENV_VERBOSE)) {
+        setenv(ENV_VERBOSE, "2", 1);
+      } else {
+        setenv(ENV_VERBOSE, "1", 1);
+      }
       cur_arg++;
     }
     else if (strcmp(cur_arg[0], "--first-deadlock") == 0 ||
@@ -66,8 +70,8 @@ main(int argc, char *argv[])
       fprintf(stderr,
               "Usage: mcmini [--max-depth-per-thread|-m <num>] "
               "[--debug-at-trace|-d <num>]\n"
-              "[--first-deadlock|--first] [--print-at-trace]\n"
-              "[--verbose|-v] [--help|-h] target_executable\n");
+              "[--first-deadlock|-first] [--print-at-trace]\n"
+              "[--verbose|-v] [-v -v] [--help|-h] target_executable\n");
       exit(1);
     }
     else {


### PR DESCRIPTION
 * '-v -v' prints full stats; '-v' prints just the thread schedules
 * Any deadlock info, etc., will be reprinted after printing "***** Model checking completed! *****\n"
    (This fixes a problem where the pinted failure quickly went off screen after the output scrolled to the end.)
 * Also: `./configure --enable-debug; CC/CXX can be any comp`