### PR TITLE
Introduce `mcmini::coordinator`

### DIFF
--- a/docs/design/include/mcmini/coordinator/coordinator.hpp
+++ b/docs/design/include/mcmini/coordinator/coordinator.hpp
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "mcmini/coordinator/model_to_system_map.hpp"
+#include "mcmini/forwards.hpp"
+#include "mcmini/model/program.hpp"
+#include "mcmini/model/transition_registry.hpp"
+#include "mcmini/model/visible_object.hpp"
+#include "mcmini/real_world/process_source.hpp"
+#include "mcmini/real_world/runner.hpp"
+
+namespace mcmini {
+
+/**
+ * @brief A mechanism which synchronizes a McMini model of a program
+ * (`mcmini::model::program`) with a process executing that modeled program
+ * (`mcmini::real_world::process`).
+ *
+ * Model-checking algorithms in McMini operate strictly on program models
+ * (`mcmini::model::program`) and not directly with the raw memory contents of
+ * a running process. McMini must work to continuously synchronize the _model_
+ * it maintains of a program undergoing verification with the progression of the
+ * _actual process_ whose state (i.e. memory) _is represented by_ that model.
+ * Below is a schema of the synchronization the tracecoordinator performs.
+ *
+ *  +-------+                             +----------------------+
+ * | model |     kept synchronized       |     corresponding    |
+ * |  of   |  <------------------------> |      process         |
+ * |  the  |                             +----------------------+
+ * | world |                            |        |        |
+ * +-------+                           +---+    +---+    +---+
+ *                                    |t_0i|   |t_1j|   |t_2k| ...
+ *                                    +---+    +----+   +----+
+ *                                      /        /        /
+ *                                    +---+    +---+    +---+
+ *                                   |????|   |????|   |????| ...
+ *                                   +---+    +----+   +----+
+ *
+ * However, since McMini is an explicit-state model checker, a model can only be
+ * constructed through the _execution_ of actual processes running in user space
+ * (e.g. `fork()`-ed from a shell).
+ *
+ * Recall that a `mcmini::model::program` consists of a mapping between the
+ * individual execution units of the program ("threads") and the next step that
+ * thread will take once executed.
+ *
+ * A `mcmini::model::program`, among other things, must describe _how_ the model
+ * in its current state can transition into a different state. But since _only_
+ * the next immediate action (the "thread routine", e.g. `pthread_mutex_lock()`)
+ * that will be taken by any thread `i` in that process is known _for
+ * certain_ (all subsequent actions taken by any thread `i` are unknown), McMini
+ * must coordinate changes in the process with changes in the model. After a
+ * thread has executed its next immediate action in the process, its
+ * the action that the thread will _later_ run (i.e. the subsequent action that
+ * follows immediately after the given one) is discovered dynamically at
+ * runtime. The diagram below illustrates the progre
+ *
+ *              run thread 0 ------------------------+
+ *                                                   |
+ *                                                  +
+ *  +-------+                             +----------------------+
+ * | model |     kept synchronized       |     corresponding    |
+ * |  of   |  <------------------------> |      process         |
+ * |  the  |                             +----------------------+
+ * | world |                            |        |        |
+ * +-------+     update the model      +---+    +---+    +---+
+ *       +---------------------------|*t_0i*|  |t_1j|   |t_2k| ...
+ *                                    +---+    +----+   +----+
+ *                                      /\        /        /
+ *                                    +---+    +---+    +---+
+ *  discovered _after_`t_0i`------->|t_0(i+1)||????|   |????| ...
+ *                                   +---+    +----+   +----+
+ *                                     /         /        /
+ *                                    +---+    +---+    +---+
+ *                                   |????|   |????|   |????| ...
+ *                                   +---+    +----+   +----+
+ *
+ * The coordinator is responsible for this dynamic discovery and the
+ * aforementioned synchronization.
+ */
+class coordinator {
+ public:
+  /**
+   * @brief Constructs a new coordinator which synchronizes processes.
+   *
+   * @param initial_state the state from which the coordinator begins
+   * coordination with . This is often referred to as `s_0` or the "initial
+   * state" in the model-checking literature.
+   * @param runtime_transition_mapping a registry which describes how to
+   * translate information from the `process_source` into transitions that can
+   * be consumed by the `mcmini::model::program` maintained by the coordinator.
+   * @param process_source a process source which can repeatedly produce
+   * processes starting at state `initial_state`. The coordinator will
+   * repeatedly create new processes from this source part of its exploration.
+   * @invariant: A _critical_ invariant is that _process_source_ create new
+   * processed that are modeled by _initial_state_. McMini model-checking
+   * algorithms rely _solely_ on the model to make determinations about how to
+   * explore the state space of processes constructed by _process_source_. The
+   * coordinator only ensures that the process and the state remain synchornized
+   * _after_ executions take place. If the initially modeled state does not
+   * correspond to the processes produced by `process_source`, the behavior is
+   * undefined (most likely this would lead to deadlocks etc.).
+   */
+  coordinator(model::program &&initial_state,
+              model::transition_registry &&runtime_transition_mapping,
+              std::unique_ptr<real_world::process_source> &&process_source);
+  ~coordinator() = default;
+
+  const model::program &get_current_program_model() const {
+    return this->current_program_model;
+  }
+
+  /**
+   * @brief Returns the number of steps into the program the coordinator has
+   * directed programs.
+   *
+   * The depth into the program is the number of transitions which have been
+   * executed by the coordinator.
+   */
+  uint32_t get_depth_into_program() const {
+    return current_program_model.get_trace().count();
+  }
+
+  /**
+   * @brief Return execution to correspond to the world as it looked the given
+   * number of steps into execution.
+   *
+   * The coordinator can be scheduled to restore the model and the external
+   * world to correspond to how it looked in the past. This is useful for model
+   * checkers that wish to return to a previous state along a path already.
+   *
+   * The method has no effect if `n == get_depth_into_program()`.
+   *
+   * @throws an exception is raised if the step `n` has not been recorded by
+   * this coordinator.
+   */
+  void return_to_depth(uint32_t n);
+
+  /**
+   * @brief Coordinate the execution of the runner with the given id in both the
+   * model and the external world.
+   *
+   * When the coordinator is scheduled to execute a runner, the following
+   * sequence of events take place:
+   *
+   * 1. the next transition `t_runner` that McMini has modeled for the runner to
+   * execute is applied to the coordinator's model (`current_program_model`).
+   * The resulting state is added to the state sequence `S` and the transition
+   * `t_runner` is recorded by the program model.
+   * 2. the handle to the currently live process is scheduled to execute the
+   * runner with the corresponding id. The process's write handle is written
+   * into using the appropriate serialization function registered at runtime for
+   * the transition.
+   * 3. after the process has completed execution, the coordinate reads from the
+   * process' read handle and invokes the appropriate deserialization function.
+   *
+   * The coordinator passes itself as part of the deserialization and
+   * serialization processes. During the deserialization phase, objects may be
+   * newly discovered. After execution, any such objects will be recorded.
+   *
+   * @param id the runner (thread) which should run.
+   */
+  void execute_runner(runner::runner_id_t id);
+
+ private:
+  model::program current_program_model;
+  model::transition_registry runtime_transition_mapping;
+  std::unique_ptr<real_world::process> current_process_handle;
+  std::unique_ptr<real_world::process_source> process_source;
+
+  /// @brief A mapping between remote addresses in the processes produced by
+  /// `process_source` and those of the
+  std::unordered_map<void *, model::state::objid_t> system_address_mapping;
+
+  /// Allow modifications through the `model_to_system_map` (implementation
+  /// detail)
+  friend model_to_system_map;
+};
+
+};  // namespace mcmini

--- a/docs/design/include/mcmini/coordinator/model_to_system_map.hpp
+++ b/docs/design/include/mcmini/coordinator/model_to_system_map.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "mcmini/forwards.hpp"
+#include "mcmini/misc/optional.hpp"
+#include "mcmini/model/state.hpp"
+
+namespace mcmini {
+/**
+ * @brief A mapping between the remote addresses pointing to the C/C++ structs
+ * the objects in McMini's model are emulating.
+ *
+ * As McMini explores different paths of execution of the target program at
+ * runtime, it may discover new visible objects. However, visible objects are
+ * only a _representation in the McMini model_ of the actual underlying
+ * structs containing the information used to implement the primitive. The
+ * underlying process, however, refers to these objects as pointers to the
+ * multi-threaded primitives (e.g. a `pthread_mutex_t*` in
+ * `pthread_mutex_lock()`). McMini therefore needs to maintain a
+ * correspondence between these addresses and the identifiers in McMini's
+ * model used to represent those objects to the model checker.
+ */
+struct model_to_system_map final {
+ private:
+  coordinator &_coordinator;
+  model_to_system_map(coordinator &coordinator) : _coordinator(coordinator) {}
+  friend coordinator;
+
+ public:
+  model_to_system_map() = delete;
+
+  /**
+   * @brief Retrieve the remote address of the object with id `id`.
+   *
+   * TODO: See the TODOs below
+   */
+  void *get_remote_process_handle_for_object(model::state::objid_t id) const;
+
+  /**
+   * @brief Retrieve the object that corresponds to the given remote address, or
+   * the empty optional if no such address exists.
+   *
+   * @return the id of the object in McMini's model that
+   * `remote_process_visible_object_handle` refers to, or an empty optional if
+   * no such object exists representing `remote_process_visible_object_handle`
+   */
+  mcmini::optional<model::state::objid_t> get_object_for_remote_process_handle(
+      void *remote_process_visible_object_handle) const;
+
+  /**
+   * @brief Record the presence of a new visible object that is
+   * represented with the system id `system_handle`.
+   *
+   * @param remote_process_visible_object_handle the address containing
+   * the data for the new visible object across process handles of the
+   *
+   * TODO: Handles are assumed to remain valid _across process source
+   * invocations_. In the future we could support the ability to _remap_
+   * process handles dynamically during each new re-execution scheduled by
+   * the coordinator to handle aliasing etc.
+   *
+   * TODO: The handle could be _any_ value that is used in the
+   * multi-threaded program. For now, we restrict it to addresses for the
+   * mutex case etc.
+   *
+   * TODO: This should probably have a `result` as a return type. If the
+   * handle is already mapped, how we should deal with this situation is a
+   * bit unclear.
+   *
+   * @returns the id assigned to the new object in McMini's model which
+   * corresponds to `remote_process_visible_object_handle`
+   */
+  model::state::objid_t record_new_object_association(
+      void *remote_process_visible_object_handle,
+      std::unique_ptr<mcmini::model::visible_object_state> initial_state);
+
+  /**
+   * @brief Retrieve the visible object whose address is
+   * `remote_process_visible_object_handle`, or create a new object with an
+   * initial state `fallback_initial_state` if such an object doesn't exist
+   *
+   * @returns the id assigned to the new object in McMini's model which
+   * corresponds to `remote_process_visible_object_handle`
+   */
+  model::state::objid_t observe_remote_process_handle(
+      void *remote_process_visible_object_handle,
+      std::unique_ptr<mcmini::model::visible_object_state>
+          fallback_initial_state);
+};
+
+}  // namespace mcmini

--- a/docs/design/src/mcmini/coordinator/coordinator.cpp
+++ b/docs/design/src/mcmini/coordinator/coordinator.cpp
@@ -1,0 +1,68 @@
+#include "mcmini/coordinator/coordinator.hpp"
+
+using namespace mcmini;
+
+coordinator::coordinator(
+    model::program &&initial_state,
+    model::transition_registry &&runtime_transition_mapping,
+    std::unique_ptr<real_world::process_source> &&process_source)
+    : current_program_model(std::move(initial_state)),
+      runtime_transition_mapping(std::move(runtime_transition_mapping)),
+      process_source(std::move(process_source)) {
+  // TODO: This may not be appropriate at construction time. Probably we only
+  // need to do this when we actual ask the coordinator to do anything.
+  this->current_process_handle = this->process_source->make_new_process();
+}
+
+void coordinator::execute_runner(runner::runner_id_t runner_id) {
+  std::istream &wrapper_response_stream =
+      this->current_process_handle->execute_runner(runner_id);
+  model::transition_registry::runtime_type_id transition_registry_id;
+
+  wrapper_response_stream >> transition_registry_id;
+
+  // TODO: Handle the case where lookup fails (this indicates a failure on the
+  // end of libmcmini.so... we should probably abort?)
+  model_to_system_map remote_address_mapping = model_to_system_map(*this);
+  model::transition_registry::transition_discovery_callback callback_function =
+      runtime_transition_mapping.get_callback_for(transition_registry_id);
+  std::unique_ptr<model::transition> transition_encountered_at_runtime =
+      callback_function(wrapper_response_stream, remote_address_mapping);
+  this->current_program_model.model_executing_runner(
+      runner_id, std::move(transition_encountered_at_runtime));
+}
+
+void *model_to_system_map::get_remote_process_handle_for_object(
+    model::state::objid_t id) const {
+  // TODO:impl
+  return nullptr;
+}
+
+mcmini::optional<model::state::objid_t>
+model_to_system_map::get_object_for_remote_process_handle(void *handle) const {
+  if (_coordinator.system_address_mapping.count(handle) > 0) {
+    return mcmini::optional<model::state::objid_t>(
+        _coordinator.system_address_mapping[handle]);
+  }
+  return mcmini::optional<model::state::objid_t>();
+}
+
+model::state::objid_t model_to_system_map::record_new_object_association(
+    void *remote_process_visible_object_handle,
+    std::unique_ptr<mcmini::model::visible_object_state> initial_state) {
+  // TODO: Create a new object through the coordinator and then map handle
+  // `remote_process_visible_object_handle` to the newly-created object.
+  return 0;
+}
+
+model::state::objid_t model_to_system_map::observe_remote_process_handle(
+    void *remote_process_visible_object_handle,
+    std::unique_ptr<mcmini::model::visible_object_state>
+        fallback_initial_state) {
+  return this
+      ->get_object_for_remote_process_handle(
+          remote_process_visible_object_handle)
+      .value_or(this->record_new_object_association(
+          remote_process_visible_object_handle,
+          std::move(fallback_initial_state)));
+}


### PR DESCRIPTION
# Overview

This commit introduces the `mcmini::coordinator` (hereby referred to as the “coordinator”). The coordinator maintains the correspondence between the model and the process(es) over which McMini has control. The coordinator can move execution forward and backwards in time.

In short, **it is the interface provided to model-checking algorithms**

## Example: A Walkthrough of the Synchronization

1. Receive a [notification from the model-checker that execution](https://github.com/maxwellpirtle/mcmini/blob/0fc50818c047fb2c8a360d774ea409fbfec2be34/docs/design/include/mcmini/coordinator/coordinator.hpp#L138-L162) of the specified thread should continue.

This method takes the form of 
```cpp
void execute_runner(runner::runner_id_t id);
```

The model checker [can query the coordinator for its current model] (https://github.com/maxwellpirtle/mcmini/blob/0fc50818c047fb2c8a360d774ea409fbfec2be34/docs/design/include/mcmini/coordinator/coordinator.hpp#L108C25-L110) to make a determination about which thread should be executed.

2. [Move the execution of the target program](https://github.com/maxwellpirtle/mcmini/blob/0fc50818c047fb2c8a360d774ea409fbfec2be34/docs/design/src/mcmini/coordinator/coordinator.cpp#L18-L22) (e.g. `dining_philosophers`) a single step

The coordinator keeps a handle to a `mcmini::real_world::process`. This will be introduced in a separate PR; for now think of it simply as a proxy (as a C++ object) in the `mcmini` process for some other process.

```cpp
...
  std::istream &wrapper_response_stream = this->current_process_handle->execute_runner(runner_id);
...
```

4.  Based on the response from the runner, the coordinator will determine the transition that the runner is now currently blocked at.

It performs a lookup in its local `model::transition_registry`. This is a mapping which associates actions taken in the `mcmini::real_world::process` with their translations into the McMini model

```cpp
...
  model::transition_registry::runtime_type_id transition_registry_id;
  wrapper_response_stream >> transition_registry_id;
...
```
```cpp
  model_to_system_map remote_address_mapping = model_to_system_map(*this);
  model::transition_registry::transition_discovery_callback callback_function = runtime_transition_mapping.get_callback_for(transition_registry_id);
  std::unique_ptr<model::transition> transition_encountered_at_runtime = callback_function(wrapper_response_stream, remote_address_mapping);
```

Based on this identifier, we update the model's "next step" for the given runner and model the execution of the transition that McMini previously recorded for execution: 

```cpp
  this->current_program_model.model_executing_runner(runner_id, std::move(transition_encountered_at_runtime));
```

## Runners vs. Threads

In this PR and those to follow, you'll see that these PRs make use of the generic word "runner." For now, we're dealing strictly with multi-threaded programs. The formal definitions of (e.g. in [Rodríguez et al](https://doi.org/10.48550/arXiv.1507.00980), Flanagan and Godefroid, to name a few) describes the execution of abstract _processes_. Such a process could represent, e.g., an entire Linux process. Since the name _process_ is overloaded, I've opted to use the word _runner_