### PR TITLE
Introduce `mcmini::model::*` and friends

### DIFF
--- a/docs/design/include/mcmini/model/objects/mutex.hpp
+++ b/docs/design/include/mcmini/model/objects/mutex.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+#include "mcmini/model/visible_object_state.hpp"
+
+namespace mcmini::model::objects {
+
+struct mutex : public mcmini::model::visible_object_state {
+ public:
+  /* The four possible states for a mutex */
+  enum state_type { uninitialized, unlocked, locked, destroyed };
+
+ private:
+  state_type current_state = state_type::uninitialized;
+
+ public:
+  mutex() = default;
+  ~mutex() = default;
+  mutex(const mutex &) = default;
+  mutex(state_type state) : current_state(state) {}
+  static std::unique_ptr<mutex> make(state_type state) {
+    return mcmini::extensions::make_unique<mutex>(state);
+  }
+
+  // ---- State Observation --- //
+  bool operator==(const mutex &other) const {
+    return this->current_state == other.current_state;
+  }
+  bool operator!=(const mutex &other) const {
+    return this->current_state != other.current_state;
+  }
+  bool is_locked() const { return this->current_state == locked; }
+  bool is_unlocked() const { return this->current_state == unlocked; }
+  bool is_destroyed() const { return this->current_state == destroyed; }
+  bool is_initialized() const { return this->current_state != uninitialized; }
+
+  std::unique_ptr<visible_object_state> clone() const override {
+    return mcmini::extensions::make_unique<mutex>(*this);
+  }
+};
+
+}  // namespace mcmini::model::objects

--- a/docs/design/include/mcmini/model/objects/thread.hpp
+++ b/docs/design/include/mcmini/model/objects/thread.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+#include "mcmini/model/visible_object_state.hpp"
+
+namespace mcmini::model::objects {
+
+struct thread : public mcmini::model::visible_object_state {
+ public:
+  /* The four possible states for a mutex */
+  enum state_type { embryo, running, exited, killed };
+
+ private:
+  state_type current_state = state_type::embryo;
+
+ public:
+  thread() = default;
+  ~thread() = default;
+  thread(const thread &) = default;
+  thread(state_type state) : current_state(state) {}
+  static std::unique_ptr<thread> make(state_type state) {
+    return mcmini::extensions::make_unique<thread>(state);
+  }
+  static std::unique_ptr<thread> make() { return thread::make(embryo); }
+
+  // ---- State Observation --- //
+  bool operator==(const thread &other) const {
+    return this->current_state == other.current_state;
+  }
+  bool operator!=(const thread &other) const {
+    return this->current_state != other.current_state;
+  }
+  bool is_embryo() const { return this->current_state == embryo; }
+  bool is_running() const { return this->current_state == running; }
+  bool has_exited() const { return this->current_state == exited; }
+  bool is_killed() const { return this->current_state == killed; }
+
+  std::unique_ptr<visible_object_state> clone() const override {
+    return mcmini::extensions::make_unique<thread>(*this);
+  }
+};
+
+}  // namespace mcmini::model::objects

--- a/docs/design/include/mcmini/model/pending_transitions.hpp
+++ b/docs/design/include/mcmini/model/pending_transitions.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A collection of "next steps" for a set of threads running in a
+ * `mcmini::model::program`
+ *
+ * An important component of a program are the possible ways that is can evolve.
+ * Evolution is described in McMini as _transitions_ -- functions of state which
+ * produce a state `s'` from a given state `s`. Conceptually,
+ * `pending_transitions` is a mapping of runner ids to transitions.
+ */
+struct pending_transitions final {
+ private:
+  using runner_id_t = uint32_t;
+  std::unordered_map<runner_id_t, std::unique_ptr<const transition>> _contents;
+
+ public:
+  auto begin() -> decltype(_contents.begin()) { return _contents.begin(); }
+  auto end() -> decltype(_contents.end()) { return _contents.end(); }
+  auto begin() const -> decltype(_contents.cbegin()) {
+    return _contents.cbegin();
+  }
+  auto end() const -> decltype(_contents.cend()) { return _contents.cend(); }
+  auto cbegin() -> decltype(_contents.cbegin()) const {
+    return _contents.cbegin();
+  }
+  auto cend() -> decltype(_contents.cend()) const { return _contents.cend(); }
+  /**
+   * @brief Returns the transition mapped to id `id`, or `nullptr` if no such
+   * runner has been mapped to an id.
+   *
+   * @param id the id of the runner whose transition should be retrieved.
+   */
+  const transition *get_transition_for_runner(runner_id_t id) const {
+    if (_contents.count(id) > 0) {
+      return _contents.at(id).get();
+    }
+    return nullptr;
+  }
+
+  std::unique_ptr<const transition> displace_transition_for(
+      runner_id_t id, std::unique_ptr<const transition> new_transition) {
+    auto old_transition = std::move(_contents[id]);
+    _contents.insert({id, std::move(new_transition)});
+    return old_transition;
+  }
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/private/serialization.hpp
+++ b/docs/design/include/mcmini/model/private/serialization.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <ostream>
+
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model {
+
+// -----------------------------------------------------------------------------
+// -----McMini Private API (inside McMini executable that runs the checker)-----
+// -----------------------------------------------------------------------------
+
+// Some metaprogramming here gives us a nice way to avoid creating serializers
+// for types that do not subclass `transition`.
+template <typename T, typename Enable = void>
+class serializer;
+
+template <typename T>
+class serializer<
+    T, typename std::enable_if<std::is_base_of<transition, T>::value &&
+                               std::is_class<T>::value>::type> {
+ public:
+  static void serialize(T* subtype, std::ostream& os) {
+    // TODO: Look up identifier for the specific type --> look at the global
+    // registry!
+    // TODO: Decide if the registry is "global" or passed in. Probably as an
+    // argument but we need to think about it (i.e. whether the singleton
+    // pattern is appropriate here)
+    int specific_id_for_subtype = 10;
+    os << typeid(*T).hash_code();
+    serializeInto(subtype, os);
+
+    // Do other work here
+
+    // Flush the stream e.g. (ensure the write actually is carried out)
+    os.flush();
+  }
+};
+
+// This is a private template that McMini invokes to serialize a transition
+// that it's sending to libmcmini.so. This ensures that the specific type is
+// used.
+template <typename T>
+void serialize_transition(T* subtype, std::ostream& os) {
+  serializer<T>::serialize(subtype, os);
+}
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/program.hpp
+++ b/docs/design/include/mcmini/model/program.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "mcmini/model/pending_transitions.hpp"
+#include "mcmini/model/state/state_sequence.hpp"
+#include "mcmini/model/transitions/transition_sequence.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A capture of the states visited in a particular branch of the state
+ * space of a program undergoing verification; a trace describing how the
+ * current state has come about as a sequence of transitions; and the
+ * immediately visible "next steps" that can be taken by the program in its
+ * current state.
+ *
+ * A program is an interface between a live process running on the CPU under
+ * control of the operating system and the view of that process from the
+ * perspective of the verifier. A _mcmini::model::program_ is a container that
+ * comprises of the following three components:
+ *
+ * - a sequence `S` of transitions that have occurred called a _trace_.
+ * - a model of the state of the program undergoing verification after each
+ * point `t` in trace `S`.
+ * - a mapping between the individual execution units of the program ("threads")
+ * and the next thread routine ("transition") that thread will run once
+ * executed.
+ *
+ * Each component corresponds directly to the theoretical models described in
+ * Flanagan et al., Rodriguez et al., etc; specifically
+ *
+ * - the sequence `S` of transitions is some linearization of transitions that
+ * the given program has followed to reach its current state.
+ * - the model of the program at each point models how the state of the program
+ * at each point during the sequence (s_0, s_1, ..., s_N). Each transition `t_i
+ * in `S` describes how the program went from state `s_i` to `s_(i+1)`.
+ * - the mapping of execution units to threads represents `next(s_N, p)`.
+ *
+ * Conceptually, the program's _current state_ is that state reached from
+ * executing the sequence `S` of transitions in the order they appear from the
+ * initial state `s_0` of the program. This is sometimes represented as
+ * `state(S)` where `S` is some transition sequence and `s_0` is assumed to be
+ * implied.
+ */
+class program {
+ private:
+  state_sequence state_seq;
+  transition_sequence trace;
+  pending_transitions next_steps;
+
+ public:
+  using runner_id_t = uint32_t;
+
+  program(state &&initial_state, pending_transitions &&initial_first_steps);
+  program(program &&) = default;
+  program(const program &) = delete;
+
+  const state_sequence &get_state_sequence() const { return this->state_seq; }
+  const transition_sequence &get_trace() const { return this->trace; }
+
+  /**
+   * @brief Returns a list of runners which are currently enabled.
+   */
+  std::unordered_set<runner_id_t> get_enabled_runners() const {
+    std::unordered_set<runner_id_t> enabled_runners;
+    for (const auto &runner_and_t : this->next_steps) {
+      if (runner_and_t.second->is_enabled_in(state_seq)) {
+        enabled_runners.insert(runner_and_t.first);
+      }
+    }
+    return enabled_runners;
+  }
+
+  void model_executing_runner(runner_id_t p,
+                              std::unique_ptr<transition> new_transition) {
+    const transition *next_s_p = next_steps.get_transition_for_runner(p);
+
+    if (next_s_p) {
+      this->state_seq.follow(*next_s_p);
+      this->next_steps.displace_transition_for(p, std::move(new_transition));
+    } else {
+      // TODO: Handle the case where `p` doesn't exist. Perhaps this function
+      // should return a `mcmini::result<>` type.
+      throw std::runtime_error(
+          "Attempted to execute a runner whose transition was not currently "
+          "enabled");
+    }
+  }
+};
+//
+
+};  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/state.hpp
+++ b/docs/design/include/mcmini/model/state.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "mcmini/forwards.hpp"
+#include "mcmini/misc/asserts.hpp"
+#include "mcmini/model/visible_object.hpp"
+
+namespace mcmini::model {
+/**
+ * @brief A particular snapshot in time of a program undergoing verification
+ * from the perspective of McMini.
+ */
+class state {
+ public:
+  using objid_t = uint32_t;
+
+  virtual ~state() = default;
+  virtual bool contains_object_with_id(objid_t id) const = 0;
+  virtual const visible_object_state *get_state_of_object(objid_t id) const = 0;
+  virtual std::unique_ptr<mutable_state> mutable_clone() const = 0;
+
+  // TODO: Potentially provide an interface here that conforms to C++11's
+  // iteration (a begin() and end() as virtual functions perhaps).
+  // Each subclass can return the same `state_iterator` type that
+  // is defined elsewhere which should provide a pair of objid_t
+  // and const visible_object_state* associated with that id.
+
+  template <typename StateType, typename ForwardIter, typename... Args>
+  static std::unique_ptr<StateType> from_visible_object_states(
+      ForwardIter begin, ForwardIter end, Args &&...args) {
+    auto state =
+        mcmini::extensions::make_unique<StateType>(std::forward<Args>(args)...);
+    for (auto elem = begin; elem != end; elem++) {
+      state->add_object((*elem)->clone());
+    }
+    return state;
+  }
+
+  template <typename StateType, typename ForwardIter, typename... Args>
+  static std::unique_ptr<StateType> from_visible_objects(ForwardIter begin,
+                                                         ForwardIter end,
+                                                         Args &&...args) {
+    auto state =
+        mcmini::extensions::make_unique<StateType>(std::forward<Args>(args)...);
+    for (auto elem = begin; elem != end; elem++) {
+      state->add_object((*elem).get_current_state()->clone());
+    }
+    return state;
+  }
+
+  template <typename concrete_visible_object_state>
+  const concrete_visible_object_state *get_state_of_object(objid_t id) const {
+    static_assert(std::is_base_of<visible_object_state,
+                                  concrete_visible_object_state>::value,
+                  "Concrete type must be a subtype of `visible_object_state`");
+    return static_cast<const concrete_visible_object_state *>(
+        this->get_state_of_object(id));
+  }
+};
+
+class mutable_state : public state {
+ public:
+  virtual ~mutable_state() = default;
+
+  /**
+   * @brief Begin tracking a new visible object _obj_ to this state.
+   *
+   * @param initial_state the initial state of the object
+   * @return the new id that is assigned to the object. This id is unique from
+   * every other id assigned to the objects in this state.
+   */
+  virtual objid_t add_object(
+      std::unique_ptr<visible_object_state> initial_state) = 0;
+
+  /**
+   * @brief Adds the given state _state_ for the object with id _id_.
+   *
+   * @note: If the object with id `id` is _not_ a visible object tracking states
+   * of type `visible_object_state_type`, the behavior of this function is
+   * undefined.
+   */
+  virtual void add_state_for(
+      objid_t id, std::unique_ptr<visible_object_state> new_state) = 0;
+
+  /**
+   * @brief Creates a copy of the given state.
+   *
+   * All visible objects in the underlying state are copied into the new state
+   * and are independently modifiable with respect to the first state.
+   */
+  std::unique_ptr<mutable_state> clone() const { return this->mutable_clone(); }
+
+  template <typename concrete_visible_object_state>
+  const concrete_visible_object_state *get_state_of_object(objid_t id) const {
+    return (static_cast<const state *>(this))
+        ->get_state_of_object<concrete_visible_object_state>();
+  }
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/state/detached_state.hpp
+++ b/docs/design/include/mcmini/model/state/detached_state.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "mcmini/misc/append-only.hpp"
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+#include "mcmini/model/state.hpp"
+#include "mcmini/model/visible_object.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A collection of visible object states.
+ *
+ * A `detached_state` is one which defines a state of a program outside of the
+ * context of a sequence; that is, a detached state represents the states
+ */
+class detached_state : public mutable_state {
+ private:
+  mcmini::append_only<visible_object> visible_objects;
+
+ public:
+  detached_state() = default;
+  detached_state(const detached_state &) = default;
+  detached_state(detached_state &&) = default;
+  detached_state &operator=(const detached_state &) = default;
+  detached_state &operator=(detached_state &&) = default;
+
+  /* `state` overrrides */
+  virtual bool contains_object_with_id(objid_t id) const override;
+  virtual const visible_object_state *get_state_of_object(
+      objid_t id) const override;
+  virtual objid_t add_object(
+      std::unique_ptr<visible_object_state> initial_state) override;
+  virtual void add_state_for(
+      objid_t id, std::unique_ptr<visible_object_state> new_state) override;
+  virtual std::unique_ptr<mutable_state> mutable_clone() const override;
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/state/state_sequence.hpp
+++ b/docs/design/include/mcmini/model/state/state_sequence.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "mcmini/forwards.hpp"
+#include "mcmini/misc/append-only.hpp"
+#include "mcmini/model/state.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A sequence of states.
+ *
+ * A _state sequence_ is a sequence of states with the following properties:
+ *
+ * 1. for each state `s_i`, there exists some transition `t_i` such that `t_i`
+ * is defined at `s_i` (`t_i` is enabled there) and `s_{i+1} = t_i(s_i)`. That
+ * is, given any pair of states `s_i` and `s_j` in the sequence (i <= j), there
+ * exists a sequence of transitions `t_i, ..., t_j` such that `s_j =
+ * t_j(t_{j-1}(...(t_i(s_i))...))`
+ */
+class state_sequence : public state {
+ private:
+  /**
+   * @brief An element of a `mcmini::model::state_sequence`
+   *
+   * The `element` and `state_sequence` are tightly intertwined. We allow them
+   * to work in tandem with one another as an implementation detail to permit
+   * "views" of the objects the state sequence maintains as new states are added
+   * to the sequence via transitions
+   */
+  class element : public state {
+   private:
+    /// @brief A collection of references to states in the sequence
+    /// _owning_sequence_ to which this element belongs.
+    ///
+    /// Each state in the view
+    std::vector<const visible_object_state *> visible_object_states;
+
+    element(const state_sequence &owner);
+    friend state_sequence;
+
+   public:
+    virtual bool contains_object_with_id(objid_t id) const override;
+    virtual const visible_object_state *get_state_of_object(
+        objid_t id) const override;
+    virtual std::unique_ptr<mutable_state> mutable_clone() const override;
+  };
+
+  /**
+   * @brief A state which maintains changes to an underlying base state.
+   *
+   * A `diff_state` manages the changes in state of objects which exist in a
+   * given state, as well as any newly-created objects
+   */
+  class diff_state;
+
+  /**
+   * @brief Consume the differences contained in the `diff_state`
+   */
+  void consume_diff(const diff_state &);
+
+  // INVARIANT: As new states are added to the visible objects in the
+  // mapping, new state views are also added with the appropriate object states
+  // replaced.
+  mcmini::append_only<visible_object> visible_objects;
+  mcmini::append_only<element> states_in_sequence;
+
+ public:
+  state_sequence() = default;
+  state_sequence(const state &);
+  state_sequence(const state &&);
+  state_sequence(state_sequence &) = delete;
+  state_sequence(state_sequence &&) = default;
+  state_sequence(std::vector<visible_object> &&);
+  state_sequence &operator=(const state_sequence &&) = delete;
+  state_sequence &operator=(const state_sequence &) = delete;
+
+  /* `state` overrrides */
+  virtual bool contains_object_with_id(state::objid_t id) const override;
+  virtual const visible_object_state *get_state_of_object(
+      objid_t id) const override;
+  virtual std::unique_ptr<mutable_state> mutable_clone() const override;
+
+  /* Applying transitions */
+
+  /**
+   * @brief Applies the given transition to the final state of the sequence if
+   * it is enabled there and pushes the adds the transformed state to the
+   * sequence.
+   *
+   * @return whether the transition was enabled at the final state in the
+   * sequence. If the transition was disabled there, a new state will _not_ be
+   * added to the sequence and a `disabled` status will be returned. Otherwise,
+   * the transition is _defined_ at the final state and a new state `s'` is
+   * added to the end of the sequence.
+   */
+  transition::status follow(const transition &t);
+
+  const state &state_at(size_t i) const {
+    return this->states_in_sequence.at(i);
+  }
+
+  /**
+   * @brief Moves the contents from index 0 to index _index_ (inclusive) of this
+   * sequence produce a the sequence formed by entries 0-index.
+   *
+   * Any `state` references which were vended by the sequence via the function
+   * `state_sequence::state_at()` which point to indices past _index_ are no
+   * longer valid after the sequence is consumed. All other views into the
+   * sequence remain valid.
+   *
+   * @param index the last index that should be contained in the returned
+   * subsequence.
+   * @return the resulting subsequence. The subsequence is identical to this
+   * sequence up to index `index`. Any objects which didn't exist prior to state
+   * `s_index` will not exist in the resulting sequence
+   */
+  state_sequence consume_into_subsequence(size_t index) &&;
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/transition.hpp
+++ b/docs/design/include/mcmini/model/transition.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <cstdint>
+
+#include "mcmini/forwards.hpp"
+#include "mcmini/misc/optional.hpp"
+#include "mcmini/model/state.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A function over states of a program.
+ *
+ * We give the formal definition of a transition from Rodriguez et al. 2018
+ * UDPOR
+ *
+ * """
+ * A system is a tuple M <`Σ, T, S_0> formed by a set Σ of global states, a set
+ * T of transitions and some initial global state ˜ s > Σ. Each transition t:
+ * Σ --> Σ in T is a partial function accounting for how the occurrence of t
+ * transforms the state of M. A transition t > T is enabled at a state s if t(s)
+ * is defined. Such t can fire at s, producing a new state s'. We let
+ * enabled(s) denote the set of transitions enabled at s.
+ * """
+ *
+ * The formal definition clarifies that a transition is _enabled_ at some state
+ * `s` iff t(s) is defined at the state. The implementation takes a slightly
+ * different approach:
+ *
+ * - a transition in McMini _may be defined_ in a state `s` but may be
+ * _disabled_ in that state; that is, McMini distinguishes between a transition
+ * which _cannot exist_ in a given state (e.g. a pthread_mutex_lock() on some
+ * mutex which isn't present) and that which _should not exist_ formally but
+ * needs to exist to describe a transition. Such a transition is said to
+ * _exist_ at that state, even if it is not technically enabled there. Only a
+ * subset of all transitions that _exist_ at a state `s` are actually enabled
+ * there (with at most one transition per thread).
+ *
+ * Formally, if a transition is defined in a state `s`, it means it's enabled
+ * there according to the formal definition. However, the definition of
+ * `mcmini::model::transition` allows the transition to produce a state _even if
+ * the process which is set to execute the transition isn't truly in a position
+ * where the transition is being executed_. Transitions perform _look ups_ on
+ * the particular state they are given
+ *
+ * For example, consider a transition "post(sem)" which takes a visible object
+ * (a semaphore) with id `sem` as an argument. The sempahore `sem` may exist in
+ * several states, say `s_1, s_2, and s_3`. Suppose thread 1 executes
+ * "post(m)" and brings the concurrent system from state `s_1` to `s_2`, and
+ * suppose that in state `s_2` thread 1 executes "wait(sem)". In state `s_2`,
+ * the transition "thread 1 executes post(sem)" is _not_ enabled since thread 1
+ * is _not_ executing a `post(sem)`. However, the implementation of "thread 1
+ * executes post(sem)"  _would be defined_ in state `s_2`. In other words, a
+ * `mcmini::model::state` _excludes_ the state of the _processes_; that is the
+ * responsibility of `mcmini::model::program`.
+ */
+class transition {
+ public:
+  /**
+   * @brief Attempts to produce a state _s'_ from state _s_ through the
+   * application of this transition function on argument _s_
+   *
+   * Recall that a transition is merely a function over the states of a
+   * concurrent system. Recall further that a transition is only a _partial_
+   * function: it need not be defined in all states of the concurrent system.
+   * This method thus returns
+   *
+   * @param s the state to pass as an argument to the transition.
+   * @returns the resulting state _s'_ that would be produced if this transition
+   * were applied to state _s_ if such a transition is defined at _s_, and
+   * otherwise the empty optional.
+   */
+  mcmini::optional<std::unique_ptr<state>> apply_to(const state& s) const {
+    std::unique_ptr<mutable_state> s_prime = s.mutable_clone();
+    return modify(*s_prime) == status::exists
+               ? mcmini::optional<std::unique_ptr<state>>(std::move(s_prime))
+               : mcmini::optional<std::unique_ptr<state>>();
+  }
+
+  /**
+   * @brief Whether the transition is defined in the given state.
+   *
+   * @param s the state to determine if this transition is enabled.
+   */
+  bool is_enabled_in(const state& s) const { return apply_to(s).has_value(); }
+
+  /**
+   * @brief A result of a modification to a state.
+   *
+   * There are two possible outcomes attempting to apply a transition
+   * function:
+   *
+   * 1. Either the transition _exists_ at this state and is thus defined at
+   * the given state.
+   * 2. Or else the transition is _not_ defined as this state and the
+   * transition is disabled.
+   */
+  enum class status { exists, disabled };
+
+  /**
+   * @brief Fire the transition as if it were run from state _state_.
+   *
+   * A transition is said to _fire_ at a state `s` of a concurrent system if
+   * that transition is enabled there and the system moves into the state `s'`
+   * the transition maps to `s`
+   *
+   * @param s the state taken as an argument to the transition function; the
+   * state which this transition is "applied to"
+   * @returns whether the transition were enabled in this state. If the
+   * transition is _not_ enabled in this state, the contents of state is
+   * undefined; otherwise, the object `state` will represent the new state `s'`
+   * reached by the system after this transition fires.
+   */
+  virtual status modify(mutable_state& s) const = 0;
+
+  // TODO: Add a serialization method here later if we want to support
+  // transitions sending different return values to the wrapper functions that
+  // they represent. The signature would be something like
+  // `virtual void serialize(std::ostream&, const
+  // mcmini::coordinator::context::model_to_system_map&) const = 0;`
+
+  virtual std::string to_string() const = 0;
+  virtual ~transition() = default;
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/transition_registry.hpp
+++ b/docs/design/include/mcmini/model/transition_registry.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+
+#include "mcmini/coordinator/coordinator.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A central repository where transitions are dynamically registered with
+ * McMini to be included during model checking.
+ *
+ * At runtime, McMini assigns a unique integer identifier to each type of
+ * transition that could exist during verification. When exploring the state
+ * space of the executable undergoing verification, McMini will be notified of
+ * threads running the registered transitions as `libmcmini.so` intercepts
+ * library calls. `libmcmini.so` will transfer the value registered at runtime
+ * along with a transition-specific payload. With the runtime id, a lookup is
+ * performed and the appropriate function pointer is invoked that knows how to
+ * represent the intercepted library call as a transition in McMini's model.
+ */
+class transition_registry final {
+ public:
+  using runtime_type_id = uint32_t;
+  using rttid = runtime_type_id;
+  using transition_discovery_callback =
+      std::unique_ptr<transition> (*)(std::istream&, model_to_system_map&);
+
+  /**
+   * @brief Marks the specified transition subclass as possible to encounter at
+   * runtime
+   *
+   * @param transition_subclass the concrete type of transition that McMini will
+   * associate with the returned id
+   * @returns a positive integer which conceptually represents the transition.
+   */
+  template <typename transition_subclass>
+  runtime_type_id register_transition(transition_discovery_callback callback) {
+    static_assert(std::is_base_of<transition, transition_subclass>::value,
+                  "Must be a subclass of `mcmini::model::transition`");
+    // TODO: Mapping between types and the serialization
+    // function pointers. For plugins loaded by McMini, each will have the
+    // chance to register the transitions it defines. Here the RTTI needs to
+    // be preserved across the plugins and McMini. There are some challenges
+    // here. See the `ld` man page and specifically the two linker flags
+    // `--dynamic-list-cpp-typeinfo` and `-E` for details. `-E` is definitely
+    // sufficient it seems in my small testing
+    runtime_callbacks.push_back(callback);
+    return runtime_callbacks.size() - 1;
+  }
+
+  /**
+   * @brief Marks the specified transition subclass as possible to encounter at
+   * runtime, choosing the default `deserialize_from_wrapper_contents` static
+   * function defined on the transition subclass if its available.
+   *
+   * @param transition_subclass the concrete type of transition that McMini will
+   * associate with the returned id
+   * @returns a positive integer which conceptually represents the transition.
+   */
+  template <typename transition_subclass>
+  runtime_type_id register_transition() {
+    return register_transition<transition_subclass>(
+        &transition_subclass::from_wrapper_contents);
+  }
+
+  /**
+   * @brief Retireve the function pointer registered for the given runtime type
+   * id this registry assigned.
+   *
+   * @returns a function pointer which can produce a new transition of the type
+   * assigned id `rttid`.
+   */
+  transition_discovery_callback get_callback_for(runtime_type_id rttid) {
+    return this->runtime_callbacks.at(rttid);
+  }
+
+ private:
+  std::vector<transition_discovery_callback> runtime_callbacks;
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/transitions/mutex/mutex_init.hpp
+++ b/docs/design/include/mcmini/model/transitions/mutex/mutex_init.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "mcmini/model/objects/mutex.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model::transitions {
+
+struct mutex_init : public mcmini::model::transition {
+ private:
+  state::objid_t mutex_id; /* The mutex this transition initializes */
+
+ public:
+  mutex_init(state::objid_t mutex_id) : mutex_id(mutex_id) {}
+  ~mutex_init() = default;
+
+  status modify(mcmini::model::mutable_state& s) const override {
+    using namespace mcmini::model::objects;
+    s.add_state_for(mutex_id, mutex::make(mutex::unlocked));
+    return status::exists;
+  }
+
+  std::string to_string() const override {
+    return "mutex_init(" + std::to_string(mutex_id) + ")";
+  }
+};
+
+}  // namespace mcmini::model::transitions

--- a/docs/design/include/mcmini/model/transitions/mutex/mutex_lock.hpp
+++ b/docs/design/include/mcmini/model/transitions/mutex/mutex_lock.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "mcmini/model/objects/mutex.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model::transitions {
+
+struct mutex_lock : public mcmini::model::transition {
+ private:
+  state::objid_t mutex_id; /* The mutex this transition initializes */
+
+ public:
+  mutex_lock(state::objid_t mutex_id) : mutex_id(mutex_id) {}
+  ~mutex_lock() = default;
+
+  status modify(mcmini::model::mutable_state& s) const override {
+    using namespace mcmini::model::objects;
+
+    // A `mutex_lock` cannot be applied to a mutex already locked.
+    const mutex* ms = s.get_state_of_object<mutex>(mutex_id);
+    if (ms->is_locked()) {
+      return status::disabled;
+    }
+    s.add_state_for(mutex_id, mutex::make(mutex::locked));
+    return status::exists;
+  }
+
+  std::string to_string() const override {
+    return "mutex_lock(" + std::to_string(mutex_id) + ")";
+  }
+};
+
+}  // namespace mcmini::model::transitions

--- a/docs/design/include/mcmini/model/transitions/thread/thread_start.hpp
+++ b/docs/design/include/mcmini/model/transitions/thread/thread_start.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "mcmini/model/objects/thread.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model::transitions {
+
+struct thread_start : public mcmini::model::transition {
+ private:
+  state::objid_t thread_id; /* The mutex this transition initializes */
+
+ public:
+  thread_start(state::objid_t thread_id) : thread_id(thread_id) {}
+  ~thread_start() = default;
+
+  status modify(mcmini::model::mutable_state& s) const override {
+    using namespace mcmini::model::objects;
+    s.add_state_for(thread_id, thread::make(thread::running));
+    return status::exists;
+  }
+
+  std::string to_string() const override {
+    return "thread_start(" + std::to_string(thread_id) + ")";
+  }
+};
+
+}  // namespace mcmini::model::transitions

--- a/docs/design/include/mcmini/model/transitions/transition_sequence.hpp
+++ b/docs/design/include/mcmini/model/transitions/transition_sequence.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <vector>
+
+#include "mcmini/model/transition.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A sequence of transitions.
+ *
+ * A _transition sequence_ describes a sequence of consecutive executions. The
+ * order that transitions appear in the sequence corresponds to how those
+ * transitions were executed one after another in a program undergoing
+ * verification. However, a transition sequence is a sequence and _only_ a
+ * sequence of transitions; it is not guaranteed to represent a possible
+ * execution path of a (or any) program; that is, there are no constraints on
+ * the enabled-ness of transitions in the sequence.
+ */
+class transition_sequence final {
+ private:
+  std::vector<std::unique_ptr<const transition>> contents;
+
+ public:
+  transition_sequence() = default;
+  transition_sequence consume_into_subsequence(uint32_t index) &&;
+
+  bool empty() const;
+  size_t count() const;
+  const transition* at(size_t i);
+  void push(std::unique_ptr<const transition>);
+};
+
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/visible_object.hpp
+++ b/docs/design/include/mcmini/model/visible_object.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <vector>
+
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+#include "mcmini/model/visible_object_state.hpp"
+
+namespace mcmini::model {
+
+/**
+ * @brief A placeholder which represents a snapshot of an object with which
+ * multiple threads interact to communicate in a program.
+ *
+ * A _visible object_, from the perspective of a model checker, are those
+ * portions of a program which are semantically interesting with respect to
+ * verification. Threads in a program interact with one another by communicating
+ * with one another through operations (known as _visible operations_) that act
+ * upon visible objects to transmit information from one thread to another.
+ *
+ * A visible object is comprised of a collection of states describing how that
+ * object appeared during the execution of a `mcmini::model::program`. All
+ * objects own the states that represent them.
+ *
+ * A visible object is represented by its most recent state. Two visible objects
+ * are considered _equal_ iff their current states are equal to one another.
+ */
+class visible_object final {
+ private:
+  std::vector<std::unique_ptr<const visible_object_state>> history;
+
+  /**
+   *@brief Construct a visible object with the given history _history_.
+   */
+  visible_object(
+      std::vector<std::unique_ptr<const visible_object_state>> history)
+      : history(std::move(history)) {}
+
+  visible_object(const visible_object &other, size_t num_states) {
+    *this = other.slice(num_states);
+  }
+
+ public:
+  visible_object(visible_object &&) = default;
+  visible_object &operator=(visible_object &&) = default;
+
+  /**
+   * @brief Construct a visible object with the given initial state.
+   *get
+   * @param initial_state the initial state of the object.
+   */
+  visible_object(std::unique_ptr<const visible_object_state> initial_state) {
+    push_state(std::move(initial_state));
+  }
+  visible_object(const visible_object &other) {
+    *this = other.slice(other.get_num_states());
+  }
+  visible_object &operator=(const visible_object &other) {
+    return *this = *other.clone();
+  }
+
+ public:
+  size_t get_num_states() const { return history.size(); }
+  const visible_object_state *state_at(size_t i) const {
+    return this->history.at(i).get();
+  }
+  const visible_object_state *get_current_state() const {
+    return this->history.back().get();
+  }
+  void push_state(std::unique_ptr<const visible_object_state> s) {
+    history.push_back(std::move(s));
+  }
+  /**
+   * @brief Produces a visible object with the first `num_states` states of this
+   * visible object.
+   *
+   * @param num_states the number of states that should be copied into the
+   * resulting visible object.
+   * @returns a visible object with identical states as this visible object for
+   * the first `num_states` states.
+   */
+  visible_object slice(size_t num_states) const {
+    auto sliced_states =
+        std::vector<std::unique_ptr<const visible_object_state>>();
+    sliced_states.reserve(num_states);
+    for (int j = 0; j < num_states; j++) {
+      sliced_states.push_back(
+          mcmini::extensions::to_const_unique_ptr(history.at(j)->clone()));
+    }
+    return visible_object(std::move(sliced_states));
+  }
+  std::unique_ptr<visible_object> clone() const {
+    return mcmini::extensions::make_unique<visible_object>(*this);
+  }
+};
+}  // namespace mcmini::model

--- a/docs/design/include/mcmini/model/visible_object_state.hpp
+++ b/docs/design/include/mcmini/model/visible_object_state.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <memory>
+
+namespace mcmini::model {
+
+/**
+ * @brief A capture of the state of a particular visible object.
+ */
+class visible_object_state {
+ public:
+  virtual ~visible_object_state() = default;
+
+  /**
+   * Create a copy of this state.
+   *
+   * @return a pointer to a new object representing an object with the same
+   * state.
+   */
+  virtual std::unique_ptr<visible_object_state> clone() const = 0;
+};
+
+}  // namespace mcmini::model

--- a/docs/design/src/mcmini/model/detached_state.cpp
+++ b/docs/design/src/mcmini/model/detached_state.cpp
@@ -1,0 +1,31 @@
+#include "mcmini/model/state/detached_state.hpp"
+
+#include "mcmini/misc/asserts.hpp"
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+
+using namespace mcmini::model;
+
+/* `state` overrrides */
+bool detached_state::contains_object_with_id(state::objid_t id) const {
+  return id < this->visible_objects.size();
+}
+
+state::objid_t detached_state::add_object(
+    std::unique_ptr<visible_object_state> new_object) {
+  visible_objects.push_back(visible_object(std::move(new_object)));
+  return visible_objects.size() - 1;
+}
+
+void detached_state::add_state_for(
+    objid_t id, std::unique_ptr<visible_object_state> new_state) {
+  this->visible_objects.at(id).push_state(std::move(new_state));
+}
+
+const visible_object_state *detached_state::get_state_of_object(
+    objid_t id) const {
+  return this->visible_objects.at(id).get_current_state();
+}
+
+std::unique_ptr<mutable_state> detached_state::mutable_clone() const {
+  return mcmini::extensions::make_unique<detached_state>(*this);
+}

--- a/docs/design/src/mcmini/model/program.cpp
+++ b/docs/design/src/mcmini/model/program.cpp
@@ -1,0 +1,8 @@
+#include "mcmini/model/program.hpp"
+
+using namespace mcmini::model;
+
+program::program(state &&initial_state,
+                 pending_transitions &&initial_first_steps)
+    : next_steps(std::move(initial_first_steps)),
+      state_seq(std::move(initial_state)) {}

--- a/docs/design/src/mcmini/model/state_sequence.cpp
+++ b/docs/design/src/mcmini/model/state_sequence.cpp
@@ -1,0 +1,126 @@
+#include "mcmini/model/state/state_sequence.hpp"
+
+#include "mcmini/misc/asserts.hpp"
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+#include "mcmini/model/state/detached_state.hpp"
+
+using namespace mcmini::model;
+
+class state_sequence::diff_state : public mutable_state {
+  //  private:
+  //   const state &base_state;
+  //   std::unordered_map<state::objid_t, visible_object> new_object_states;
+
+  //  public:
+  //   diff_state(const state &s) : base_state(s) {}
+  //   diff_state(const diff_state &ds)
+  //       : base_state(ds.base_state), new_object_states(ds.new_object_states)
+  //       {}
+  //   diff_state(detached_state &&) = delete;
+  //   diff_state &operator=(const diff_state &) = delete;
+  //   detached_state &operator=(detached_state &&) = delete;
+
+  // /* `state` overrrides */
+  // virtual bool contains_object_with_id(objid_t id) const override;
+  // virtual const visible_object_state *get_state_of_object(
+  //     objid_t id) const override;
+  // virtual objid_t add_object(
+  //     std::unique_ptr<visible_object_state> initial_state) override;
+  // virtual void add_state_for(
+  //     objid_t id, std::unique_ptr<visible_object_state> new_state) override;
+  // virtual std::unique_ptr<mutable_state> mutable_clone() const override;
+};
+
+state_sequence::state_sequence(const state &initial_state) {
+  // TODO: Iterate through all the objects and their states to make a clone
+  // Potentially allow for a move iterator to be constructed.
+}
+
+state_sequence::state_sequence(const state &&state) {
+  // TODO: Iterate through all the objects. We need to attach
+}
+
+state_sequence::state_sequence(std::vector<visible_object> &&initial_objects)
+    : visible_objects(std::move(initial_objects)) {
+  this->states_in_sequence.push_back(state_sequence::element(*this));
+}
+
+bool state_sequence::contains_object_with_id(state::objid_t id) const {
+  return id < visible_objects.size();
+}
+
+const visible_object_state *state_sequence::get_state_of_object(
+    objid_t id) const {
+  return this->visible_objects.at(id).get_current_state();
+}
+
+std::unique_ptr<mutable_state> state_sequence::mutable_clone() const {
+  return state::from_visible_objects<detached_state>(
+      this->visible_objects.cbegin(), this->visible_objects.cend());
+}
+
+transition::status state_sequence::follow(const transition &t) {
+  // Supply the transition a `diff_state` intentionally. We have control over
+  // the `apply_to` function: it simply returns a clone of the state it was
+  // provided. A `diff_state` copies only the reference to its underlying
+  // "backing" state, and only new objects will be
+  // TODO: Initialize this with a reference to this state.
+  diff_state *ds;
+  auto maybe_diff = t.apply_to(*ds);
+
+  if (maybe_diff.has_value()) {
+    const diff_state &ds_after_t =
+        static_cast<const diff_state &>(*maybe_diff.value());
+
+    // Apply the diff to the sequence itself and create a new element which
+    // refers to the latest states of all the objects. This element is a
+    // placeholder for the state of the sequence as it looks after the
+    // application of transition `t`. Later if the sequenced is queried for the
+    // state of the object.
+    this->consume_diff(ds_after_t);
+    this->states_in_sequence.push_back(element(*this));
+
+    // consume the difference
+    return transition::status::exists;
+  }
+
+  return transition::status::disabled;
+
+  // We know the
+}
+
+void state_sequence::consume_diff(const diff_state &) {
+  /* TODO: Implement consumption of new states */
+}
+
+state_sequence state_sequence::consume_into_subsequence(size_t index) && {
+  // TODO: Implementation here. The subsequence should look exactly the same
+  // as this subsequence up to index `index`.
+}
+
+state_sequence::element::element(const state_sequence &owner) {
+  for (const auto &obj : owner.visible_objects) {
+    this->visible_object_states.push_back(obj.get_current_state());
+  }
+}
+
+bool state_sequence::element::contains_object_with_id(state::objid_t id) const {
+  return id < this->visible_object_states.size();
+}
+
+const visible_object_state *state_sequence::element::get_state_of_object(
+    state::objid_t id) const {
+  return this->visible_object_states.at(id);
+}
+
+std::unique_ptr<mutable_state> state_sequence::element::mutable_clone() const {
+  return state::from_visible_object_states<detached_state>(
+      this->visible_object_states.cbegin(), this->visible_object_states.cend());
+}
+
+//////// state_sequence::diff_state ///////
+
+// std::unique_ptr<mutable_state> state_sequence::diff_state::mutable_clone()
+//     const {
+//   return mcmini::extensions::make_unique<diff_state>(this->base_state);
+// }


### PR DESCRIPTION
## Overview

This PR introduces the components that make up the McMini model. There are several important directories:

- `.` contains the most important headers. These include `visible_object_state.hpp`, `transition.hpp`, `state.hpp`, and other important high-level classes
- The `objects` subdirectory will contain the definitions of McMini visible objects (to be ported from the current codebase in later PRs).  There are two example objects in the directory: [`mutex.hpp`](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/objects/mutex.hpp#L8) and [`thread.hpp](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/objects/thread.hpp#L8)
- The `state` subdirectory which contains implementations of the `mcmini::model::state` that is used by the [coordinator](#89)
- The `transitions` subdirectory will contain the definitions of McMini's modeling of its supported transitions (e.g. [`thread_start`](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/transitions/thread/thread_start.hpp#L8) among others which are not introduced yet

## Specific Points of Confusion

The [`mcmini::model::state_sequence`](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/state/state_sequence.hpp#L24) merits the most explanation.

A `state_sequence` is a just another collection of visible objects -- the same as any `mcmini::model::state` type. However, the elements of the`state_sequence`([`state_sequence::element`](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/state/state_sequence.hpp#L34)) instead alias the pointers held by the `visible_object`s pooled by the `state_sequence`. In the 

The motivation is the observation that nearly all objects remain unaffected after executing a transition. Since modeling the execution of a transition is performed repeatedly (millions of times), we want to avoid needlessly copying all objects when most of them haven't changed. Instead, when we [follow](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/state/state_sequence.hpp#L100) a transition from the last state `s_n` of the sequence, we instead scrape the current states of the [visible objects maintained by the sequence itself](https://github.com/mcminickpt/mcmini/blob/75a68ec6a2bd61817af4e9b0a2bba017c3dddb5c/docs/design/include/mcmini/model/state/state_sequence.hpp#L68). This matches the current behavior of McMini, although the mechanics are slightly different with the change made to transitions.