### PR TITLE
Eliminate gcc warnings for 'write()'

### DIFF
--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -63,7 +63,7 @@ void
 sigusr1_handler_scheduler(int sig)
 {
   char msg[] = "*** FATAL ERROR: Trace failed unexpectedly ***\n";
-  write(STDERR_FILENO, msg, sizeof(msg));
+  assert(write(STDERR_FILENO, msg, sizeof(msg)) == sizeof(msg));
   mc_stop_model_checking(EXIT_FAILURE);
 }
 
@@ -71,7 +71,7 @@ void
 sigint_handler_scheduler(int sig)
 {
   char msg[] = "\nmcmini: interrupted\n";
-  write(STDERR_FILENO, msg, sizeof(msg));
+  assert(write(STDERR_FILENO, msg, sizeof(msg)) == sizeof(msg));
   mc_stop_model_checking(EXIT_SUCCESS);
 }
 
@@ -101,7 +101,7 @@ sigchld_handler_scheduler(int sig, siginfo_t *info, void *unused)
              traceId);
   msg[len] = '\0';
 
-  write(STDERR_FILENO, msg, len);
+  assert(write(STDERR_FILENO, msg, len) == len);
   fsync(STDERR_FILENO);
 
   // Write the trace contents out


### PR DESCRIPTION
gcc warnings:
> src/signals.cpp:66:8: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’

(and two other lines.  Now we do assert on return value to check it.)

Push in PR #102 first, to fix a bug.