### PR TITLE
Bug in flag --print-at-trace: cur_arg += 1

### DIFF
--- a/src/launch.c
+++ b/src/launch.c
@@ -69,7 +69,7 @@ main(int argc, char *argv[])
     }
     else if (strcmp(cur_arg[0], "--print-at-trace") == 0) {
       setenv(ENV_PRINT_AT_TRACE, cur_arg[1], 1);
-      cur_arg += 2;
+      cur_arg += 1;
     }
     else if (strcmp(cur_arg[0], "--help") == 0 ||
              strcmp(cur_arg[0], "-h") == 0) {


### PR DESCRIPTION
For the flag `--print-at-trace`, we had `cur_arg += 2`.  But this flag does not take an argument.   I'm changing it to `cur_arg += 1`.  Without this, using the flag will segfault.