### PR TITLE
Fix mcmini help: [--print-at-trace <num>]

### DIFF
--- a/src/launch.c
+++ b/src/launch.c
@@ -76,7 +76,7 @@ main(int argc, char *argv[])
       fprintf(stderr,
               "Usage: mcmini [--max-depth-per-thread|-m <num>] "
               "[--debug-at-trace|-d <num>]\n"
-              "[--first-deadlock|-first] [--print-at-trace]\n"
+              "[--first-deadlock|-first] [--print-at-trace <num>]\n"
               "[--verbose|-v] [-v -v] [--help|-h] target_executable\n");
       exit(1);
     }

--- a/src/launch.c
+++ b/src/launch.c
@@ -69,7 +69,7 @@ main(int argc, char *argv[])
     }
     else if (strcmp(cur_arg[0], "--print-at-trace") == 0) {
       setenv(ENV_PRINT_AT_TRACE, cur_arg[1], 1);
-      cur_arg += 1;
+      cur_arg += 2;
     }
     else if (strcmp(cur_arg[0], "--help") == 0 ||
              strcmp(cur_arg[0], "-h") == 0) {


### PR DESCRIPTION
PR #101 had the wrong fix.  The code was correct, but the help message `mcmini -h` was wrong.
This reverts PR #101 and fixes the help message.