### PR TITLE
trace: pthread_XXX(%lu) -> pthread_XXX(object:%lu)

### DIFF
--- a/src/transitions/barrier/MCBarrierEnqueue.cpp
+++ b/src/transitions/barrier/MCBarrierEnqueue.cpp
@@ -72,6 +72,6 @@ MCBarrierEnqueue::dependentWith(const MCTransition *other) const
 void
 MCBarrierEnqueue::print() const
 {
-  printf("thread %lu: pthread_barrier_wait(%lu) (enqueue)\n",
+  printf("thread %lu: pthread_barrier_wait(object:%lu) (enqueue)\n",
          this->thread->tid, this->barrier->getObjectId());
 }

--- a/src/transitions/barrier/MCBarrierInit.cpp
+++ b/src/transitions/barrier/MCBarrierInit.cpp
@@ -75,7 +75,7 @@ MCBarrierInit::dependentWith(const MCTransition *other) const
 void
 MCBarrierInit::print() const
 {
-  printf("thread %lu: pthread_barrier_init(%lu, _, %u)\n",
+  printf("thread %lu: pthread_barrier_init(object:%lu, _, %u)\n",
          this->thread->tid, this->barrier->getObjectId(),
          this->barrier->getCount());
 }

--- a/src/transitions/barrier/MCBarrierWait.cpp
+++ b/src/transitions/barrier/MCBarrierWait.cpp
@@ -82,6 +82,6 @@ MCBarrierWait::enabledInState(const MCStack *state) const
 void
 MCBarrierWait::print() const
 {
-  printf("thread %lu: pthread_barrier_wait(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_barrier_wait(object:%lu)\n", this->thread->tid,
          this->barrier->getObjectId());
 }

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -75,6 +75,6 @@ MCCondBroadcast::dependentWith(const MCTransition *other) const
 void
 MCCondBroadcast::print() const
 {
-  printf("thread %lu: pthread_cond_broadcast(%lu)\n",
+  printf("thread %lu: pthread_cond_broadcast(object:%lu)\n",
          this->thread->tid, this->conditionVariable->getObjectId());
 }

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -159,7 +159,7 @@ void
 MCCondEnqueue::print() const
 {
   printf(
-    "thread %lu: pthread_cond_wait(%lu, %lu) (awake -> asleep)\n",
+    "thread %lu: pthread_cond_wait(object:%lu, object:%lu) (awake -> asleep)\n",
     this->thread->tid, this->conditionVariable->getObjectId(),
     this->mutex->getObjectId());
 }

--- a/src/transitions/cond/MCCondInit.cpp
+++ b/src/transitions/cond/MCCondInit.cpp
@@ -89,6 +89,6 @@ MCCondInit::dependentWith(const MCTransition *other) const
 void
 MCCondInit::print() const
 {
-  printf("thread %lu: pthread_cond_init(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_cond_init(object:%lu, _)\n", this->thread->tid,
          this->conditionVariable->getObjectId());
 }

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -76,6 +76,6 @@ MCCondSignal::dependentWith(const MCTransition *other) const
 void
 MCCondSignal::print() const
 {
-  printf("thread %lu: pthread_cond_signal(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_cond_signal(object:%lu)\n", this->thread->tid,
          this->conditionVariable->getObjectId());
 }

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -137,7 +137,7 @@ void
 MCCondWait::print() const
 {
   printf(
-    "thread %lu: pthread_cond_wait(%lu, %lu) (asleep -> awake)\n",
+    "thread %lu: pthread_cond_wait(object:%lu, object:%lu) (asleep -> awake)\n",
     this->thread->tid, this->conditionVariable->getObjectId(),
     this->conditionVariable->mutex->getObjectId());
 }

--- a/src/transitions/mutex/MCMutexInit.cpp
+++ b/src/transitions/mutex/MCMutexInit.cpp
@@ -86,6 +86,6 @@ MCMutexInit::dependentWith(const MCTransition *other) const
 void
 MCMutexInit::print() const
 {
-  printf("thread %lu: pthread_mutex_init(%lu, _)\n",
+  printf("thread %lu: pthread_mutex_init(object:%lu, _)\n",
          this->thread->tid, this->mutex->getObjectId());
 }

--- a/src/transitions/mutex/MCMutexLock.cpp
+++ b/src/transitions/mutex/MCMutexLock.cpp
@@ -109,6 +109,6 @@ MCMutexLock::dependentWith(const MCTransition *transition) const
 void
 MCMutexLock::print() const
 {
-  printf("thread %lu: pthread_mutex_lock(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_mutex_lock(object:%lu)\n", this->thread->tid,
          this->mutex->getObjectId());
 }

--- a/src/transitions/mutex/MCMutexUnlock.cpp
+++ b/src/transitions/mutex/MCMutexUnlock.cpp
@@ -90,6 +90,6 @@ MCMutexUnlock::dependentWith(const MCTransition *transition) const
 void
 MCMutexUnlock::print() const
 {
-  printf("thread %lu: pthread_mutex_unlock(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_mutex_unlock(object:%lu)\n", this->thread->tid,
          this->mutex->getObjectId());
 }

--- a/src/transitions/rwlock/MCRWLockInit.cpp
+++ b/src/transitions/rwlock/MCRWLockInit.cpp
@@ -70,6 +70,6 @@ MCRWLockInit::dependentWith(const MCTransition *other) const
 void
 MCRWLockInit::print() const
 {
-  printf("thread %lu: pthread_rwlock_init(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_rwlock_init(object:%lu, _)\n", this->thread->tid,
          this->rwlock->getObjectId());
 }

--- a/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
@@ -76,6 +76,6 @@ MCRWLockReaderEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWLockReaderEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwlock_rdlock(%lu) (wait)\n",
+  printf("thread %lu: pthread_rwlock_rdlock(object:%lu) (wait)\n",
          this->thread->tid, this->rwlock->getObjectId());
 }

--- a/src/transitions/rwlock/MCRWLockReaderLock.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderLock.cpp
@@ -96,6 +96,6 @@ MCRWLockReaderLock::dependentWith(const MCTransition *other) const
 void
 MCRWLockReaderLock::print() const
 {
-  printf("thread %lu: pthread_rwlock_rdlock(%lu) (lock)\n",
+  printf("thread %lu: pthread_rwlock_rdlock(object:%lu) (lock)\n",
          this->thread->tid, this->rwlock->getObjectId());
 }

--- a/src/transitions/rwlock/MCRWLockUnlock.cpp
+++ b/src/transitions/rwlock/MCRWLockUnlock.cpp
@@ -75,6 +75,6 @@ MCRWLockUnlock::dependentWith(const MCTransition *other) const
 void
 MCRWLockUnlock::print() const
 {
-  printf("thread %lu: pthread_rwlock_unlock(%lu)\n",
+  printf("thread %lu: pthread_rwlock_unlock(object:%lu)\n",
          this->thread->tid, this->rwlock->getObjectId());
 }

--- a/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
@@ -76,6 +76,6 @@ MCRWLockWriterEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWLockWriterEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwlock_wrlock(%lu) (wait)\n",
+  printf("thread %lu: pthread_rwlock_wrlock(object:%lu) (wait)\n",
          this->thread->tid, this->rwlock->getObjectId());
 }

--- a/src/transitions/rwlock/MCRWLockWriterLock.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterLock.cpp
@@ -92,6 +92,6 @@ MCRWLockWriterLock::dependentWith(const MCTransition *other) const
 void
 MCRWLockWriterLock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wrlock(%lu) (lock)\n",
+  printf("thread %lu: pthread_rwlock_wrlock(object:%lu) (lock)\n",
          this->thread->tid, this->rwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockInit.cpp
+++ b/src/transitions/rwwlock/MCRWWLockInit.cpp
@@ -70,6 +70,6 @@ MCRWWLockInit::dependentWith(const MCTransition *other) const
 void
 MCRWWLockInit::print() const
 {
-  printf("thread %lu: pthread_rwwlock_init(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_rwwlock_init(object:%lu, _)\n", this->thread->tid,
          this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
@@ -76,6 +76,6 @@ MCRWWLockReaderEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWWLockReaderEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_rdlock(%lu) (wait)\n",
+  printf("thread %lu: pthread_rwwlock_rdlock(object:%lu) (wait)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
@@ -106,6 +106,6 @@ MCRWWLockReaderLock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockReaderLock::print() const
 {
-  printf("thread %lu: pthread_rwwlock_rdlock(%lu) (lock)\n",
+  printf("thread %lu: pthread_rwwlock_rdlock(object:%lu) (lock)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockUnlock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockUnlock.cpp
@@ -75,6 +75,6 @@ MCRWWLockUnlock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockUnlock::print() const
 {
-  printf("thread %lu: pthread_rwwlock_unlock(%lu)\n",
+  printf("thread %lu: pthread_rwwlock_unlock(object:%lu)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
@@ -79,6 +79,6 @@ MCRWWLockWriter1Enqueue::dependentWith(
 void
 MCRWWLockWriter1Enqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_wr1lock(%lu) (wait)\n",
+  printf("thread %lu: pthread_rwwlock_wr1lock(object:%lu) (wait)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
@@ -101,6 +101,6 @@ MCRWWLockWriter1Lock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockWriter1Lock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wr1lock(%lu) (lock)\n",
+  printf("thread %lu: pthread_rwlock_wr1lock(object:%lu) (lock)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
@@ -79,6 +79,6 @@ MCRWWLockWriter2Enqueue::dependentWith(
 void
 MCRWWLockWriter2Enqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_wr2lock(%lu) (wait)\n",
+  printf("thread %lu: pthread_rwwlock_wr2lock(object:%lu) (wait)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
@@ -101,6 +101,6 @@ MCRWWLockWriter2Lock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockWriter2Lock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wr2lock(%lu) (lock)\n",
+  printf("thread %lu: pthread_rwlock_wr2lock(object:%lu) (lock)\n",
          this->thread->tid, this->rwwlock->getObjectId());
 }

--- a/src/transitions/semaphore/MCSemEnqueue.cpp
+++ b/src/transitions/semaphore/MCSemEnqueue.cpp
@@ -91,6 +91,6 @@ MCSemEnqueue::dependentWith(const MCTransition *other) const
 void
 MCSemEnqueue::print() const
 {
-  printf("thread %lu: sem_wait(%lu) (awake -> asleep)\n",
+  printf("thread %lu: sem_wait(object:%lu) (awake -> asleep)\n",
          this->thread->tid, this->sem->getObjectId());
 }

--- a/src/transitions/semaphore/MCSemInit.cpp
+++ b/src/transitions/semaphore/MCSemInit.cpp
@@ -69,6 +69,6 @@ MCSemInit::dependentWith(const MCTransition *other) const
 void
 MCSemInit::print() const
 {
-  printf("thread %lu: sem_init(%lu, 0, %u)\n", this->thread->tid,
+  printf("thread %lu: sem_init(object:%lu, 0, %u)\n", this->thread->tid,
          this->sem->getObjectId(), this->sem->getCount());
 }

--- a/src/transitions/semaphore/MCSemPost.cpp
+++ b/src/transitions/semaphore/MCSemPost.cpp
@@ -75,6 +75,6 @@ MCSemPost::dependentWith(const MCTransition *other) const
 void
 MCSemPost::print() const
 {
-  printf("thread %lu: sem_post(%lu)\n", this->thread->tid,
+  printf("thread %lu: sem_post(object:%lu)\n", this->thread->tid,
          this->sem->getObjectId());
 }

--- a/src/transitions/semaphore/MCSemWait.cpp
+++ b/src/transitions/semaphore/MCSemWait.cpp
@@ -89,6 +89,6 @@ MCSemWait::enabledInState(const MCStack *) const
 void
 MCSemWait::print() const
 {
-  printf("thread %lu: sem_wait(%lu) (asleep -> awake)\n",
+  printf("thread %lu: sem_wait(object:%lu) (asleep -> awake)\n",
          this->thread->tid, this->sem->getObjectId());
 }


### PR DESCRIPTION
For greater clarity, the `STACK` BACKTRACE' now displays in this format, including 'object:' :
  thread 2: sem_wait(object:3)

where object:3 means the third object created by McMini.