### PR TITLE
Trace print operation id instead of object id

### DIFF
--- a/include/mcmini/mcmini_private.h
+++ b/include/mcmini/mcmini_private.h
@@ -210,6 +210,14 @@ extern MCDeferred<MCStack> programState;
 void mc_create_global_state_object();
 
 /**
+ * @brief Return id for the operation type of objectID
+ *
+ * This counts how many objects, i,  of the same type
+ * as objectId exist, for i < ojbectId.
+ */
+int countVisibleObjectsOfType(int objectId);
+
+/**
  * @brief Perform setup for the global program state object in
  * preparation for a new model checking session
  *

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -891,7 +891,7 @@ MCStack::printTransitionStack() const
 void
 MCStack::printNextTransitions() const
 {
-  printf("THREAD STATES\n");
+  printf("THREAD PENDING OPERATIONS\n");
   auto numThreads = this->getNumProgramThreads();
   for (auto i = 0; i < numThreads; i++) {
     this->getNextTransitionForThread(i).print();

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -223,6 +223,17 @@ mc_create_global_state_object()
   programState->start();
 }
 
+int countVisibleObjectsOfType(int objectId) {
+  int count = 0;
+  for (int i = 0; i <= objectId; i++) {
+    if (typeid(programState->getTransitionAtIndex(i)) ==
+        typeid(programState->getTransitionAtIndex(objectId))) {
+      count++;
+    }
+  }
+  return count;
+}
+
 void
 mc_prepare_to_model_check_new_program()
 {

--- a/src/transitions/barrier/MCBarrierEnqueue.cpp
+++ b/src/transitions/barrier/MCBarrierEnqueue.cpp
@@ -72,6 +72,7 @@ MCBarrierEnqueue::dependentWith(const MCTransition *other) const
 void
 MCBarrierEnqueue::print() const
 {
-  printf("thread %lu: pthread_barrier_wait(object:%lu) (enqueue)\n",
-         this->thread->tid, this->barrier->getObjectId());
+  printf("thread %lu: pthread_barrier_wait(barr:%u) (enqueue)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->barrier->getObjectId()));
 }

--- a/src/transitions/barrier/MCBarrierInit.cpp
+++ b/src/transitions/barrier/MCBarrierInit.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/barrier/MCBarrierInit.h"
+#include "mcmini/mcmini_private.h"
 
 MCTransition *
 MCReadBarrierInit(const MCSharedTransition *shmTransition,
@@ -75,7 +76,8 @@ MCBarrierInit::dependentWith(const MCTransition *other) const
 void
 MCBarrierInit::print() const
 {
-  printf("thread %lu: pthread_barrier_init(object:%lu, _, %u)\n",
-         this->thread->tid, this->barrier->getObjectId(),
+  printf("thread %lu: pthread_barrier_init(barr:%u, _, %u)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->barrier->getObjectId()),
          this->barrier->getCount());
 }

--- a/src/transitions/barrier/MCBarrierWait.cpp
+++ b/src/transitions/barrier/MCBarrierWait.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/barrier/MCBarrierWait.h"
+#include "mcmini/mcmini_private.h"
 
 MCTransition *
 MCReadBarrierWait(const MCSharedTransition *shmTransition,
@@ -82,6 +83,7 @@ MCBarrierWait::enabledInState(const MCStack *state) const
 void
 MCBarrierWait::print() const
 {
-  printf("thread %lu: pthread_barrier_wait(object:%lu)\n", this->thread->tid,
-         this->barrier->getObjectId());
+  printf("thread %lu: pthread_barrier_wait(barr:%u)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->barrier->getObjectId()));
 }

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -75,6 +75,6 @@ MCCondBroadcast::dependentWith(const MCTransition *other) const
 void
 MCCondBroadcast::print() const
 {
-  printf("thread %lu: pthread_cond_broadcast(object:%lu)\n",
-         this->thread->tid, this->conditionVariable->getObjectId());
+  printf("thread %lu: pthread_cond_broadcast(cond:%u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
 }

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -158,8 +158,8 @@ MCCondEnqueue::dependentWith(const MCTransition *other) const
 void
 MCCondEnqueue::print() const
 {
-  printf(
-    "thread %lu: pthread_cond_wait(object:%lu, object:%lu) (awake -> asleep)\n",
-    this->thread->tid, this->conditionVariable->getObjectId(),
-    this->mutex->getObjectId());
+  printf("thread %lu: pthread_cond_wait(cond:%u, mut:%u) (awake -> asleep)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+         countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/cond/MCCondInit.cpp
+++ b/src/transitions/cond/MCCondInit.cpp
@@ -1,5 +1,6 @@
 #include "mcmini/transitions/cond/MCCondInit.h"
 #include "mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp"
+#include "mcmini/mcmini_private.h"
 
 using namespace std;
 using namespace mcmini;
@@ -89,6 +90,6 @@ MCCondInit::dependentWith(const MCTransition *other) const
 void
 MCCondInit::print() const
 {
-  printf("thread %lu: pthread_cond_init(object:%lu, _)\n", this->thread->tid,
-         this->conditionVariable->getObjectId());
+  printf("thread %lu: pthread_cond_init(cond:%u, _)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
 }

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -76,6 +76,6 @@ MCCondSignal::dependentWith(const MCTransition *other) const
 void
 MCCondSignal::print() const
 {
-  printf("thread %lu: pthread_cond_signal(object:%lu)\n", this->thread->tid,
-         this->conditionVariable->getObjectId());
+  printf("thread %lu: pthread_cond_signal(cond:%u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
 }

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -136,8 +136,8 @@ MCCondWait::dependentWith(const MCTransition *other) const
 void
 MCCondWait::print() const
 {
-  printf(
-    "thread %lu: pthread_cond_wait(object:%lu, object:%lu) (asleep -> awake)\n",
-    this->thread->tid, this->conditionVariable->getObjectId(),
-    this->conditionVariable->mutex->getObjectId());
+  printf("thread %lu: pthread_cond_wait(cond:%u, mut:%u) (asleep -> awake)\n",
+      this->thread->tid,
+      countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+      countVisibleObjectsOfType(this->conditionVariable->mutex->getObjectId()));
 }

--- a/src/transitions/mutex/MCMutexInit.cpp
+++ b/src/transitions/mutex/MCMutexInit.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/mutex/MCMutexInit.h"
+#include "mcmini/mcmini_private.h"
 
 MCTransition *
 MCReadMutexInit(const MCSharedTransition *shmTransition,
@@ -86,6 +87,7 @@ MCMutexInit::dependentWith(const MCTransition *other) const
 void
 MCMutexInit::print() const
 {
-  printf("thread %lu: pthread_mutex_init(object:%lu, _)\n",
-         this->thread->tid, this->mutex->getObjectId());
+  printf("thread %lu: pthread_mutex_init(mut:%u, _)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/mutex/MCMutexLock.cpp
+++ b/src/transitions/mutex/MCMutexLock.cpp
@@ -109,6 +109,6 @@ MCMutexLock::dependentWith(const MCTransition *transition) const
 void
 MCMutexLock::print() const
 {
-  printf("thread %lu: pthread_mutex_lock(object:%lu)\n", this->thread->tid,
-         this->mutex->getObjectId());
+  printf("thread %lu: pthread_mutex_lock(mut:%u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/mutex/MCMutexUnlock.cpp
+++ b/src/transitions/mutex/MCMutexUnlock.cpp
@@ -90,6 +90,6 @@ MCMutexUnlock::dependentWith(const MCTransition *transition) const
 void
 MCMutexUnlock::print() const
 {
-  printf("thread %lu: pthread_mutex_unlock(object:%lu)\n", this->thread->tid,
-         this->mutex->getObjectId());
+  printf("thread %lu: pthread_mutex_unlock(mut:%u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockInit.cpp
+++ b/src/transitions/rwlock/MCRWLockInit.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/rwlock/MCRWLockInit.h"
+#include "mcmini/mcmini_private.h"
 
 MCTransition *
 MCReadRWLockInit(const MCSharedTransition *shmTransition,
@@ -70,6 +71,6 @@ MCRWLockInit::dependentWith(const MCTransition *other) const
 void
 MCRWLockInit::print() const
 {
-  printf("thread %lu: pthread_rwlock_init(object:%lu, _)\n", this->thread->tid,
-         this->rwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_init(rwl:%u, _)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
@@ -76,6 +76,7 @@ MCRWLockReaderEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWLockReaderEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwlock_rdlock(object:%lu) (wait)\n",
-         this->thread->tid, this->rwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_rdlock(rwl:%u) (wait)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockReaderLock.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderLock.cpp
@@ -96,6 +96,7 @@ MCRWLockReaderLock::dependentWith(const MCTransition *other) const
 void
 MCRWLockReaderLock::print() const
 {
-  printf("thread %lu: pthread_rwlock_rdlock(object:%lu) (lock)\n",
-         this->thread->tid, this->rwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_rdlock(rwl:%u) (lock)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockUnlock.cpp
+++ b/src/transitions/rwlock/MCRWLockUnlock.cpp
@@ -75,6 +75,6 @@ MCRWLockUnlock::dependentWith(const MCTransition *other) const
 void
 MCRWLockUnlock::print() const
 {
-  printf("thread %lu: pthread_rwlock_unlock(object:%lu)\n",
-         this->thread->tid, this->rwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_unlock(rwl:%u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
@@ -76,6 +76,7 @@ MCRWLockWriterEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWLockWriterEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwlock_wrlock(object:%lu) (wait)\n",
-         this->thread->tid, this->rwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_wrlock(rwl:%u) (wait)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockWriterLock.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterLock.cpp
@@ -92,6 +92,7 @@ MCRWLockWriterLock::dependentWith(const MCTransition *other) const
 void
 MCRWLockWriterLock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wrlock(object:%lu) (lock)\n",
-         this->thread->tid, this->rwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_wrlock(rwl:%u) (lock)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockInit.cpp
+++ b/src/transitions/rwwlock/MCRWWLockInit.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/rwwlock/MCRWWLockInit.h"
+#include "mcmini/mcmini_private.h"
 
 MCTransition *
 MCReadRWWLockInit(const MCSharedTransition *shmTransition,
@@ -70,6 +71,6 @@ MCRWWLockInit::dependentWith(const MCTransition *other) const
 void
 MCRWWLockInit::print() const
 {
-  printf("thread %lu: pthread_rwwlock_init(object:%lu, _)\n", this->thread->tid,
-         this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwwlock_init(rwwl:%u, _)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
@@ -76,6 +76,7 @@ MCRWWLockReaderEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWWLockReaderEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_rdlock(object:%lu) (wait)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwwlock_rdlock(rwwl:%u) (wait)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
@@ -106,6 +106,7 @@ MCRWWLockReaderLock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockReaderLock::print() const
 {
-  printf("thread %lu: pthread_rwwlock_rdlock(object:%lu) (lock)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwwlock_rdlock(rwwl:%u) (lock)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockUnlock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockUnlock.cpp
@@ -75,6 +75,7 @@ MCRWWLockUnlock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockUnlock::print() const
 {
-  printf("thread %lu: pthread_rwwlock_unlock(object:%lu)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwwlock_unlock(rwwl:%u)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
@@ -79,6 +79,7 @@ MCRWWLockWriter1Enqueue::dependentWith(
 void
 MCRWWLockWriter1Enqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_wr1lock(object:%lu) (wait)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwwlock_wr1lock(rwl:%u) (wait)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
@@ -101,6 +101,7 @@ MCRWWLockWriter1Lock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockWriter1Lock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wr1lock(object:%lu) (lock)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_wr1lock(rwwl:%u) (lock)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
@@ -79,6 +79,7 @@ MCRWWLockWriter2Enqueue::dependentWith(
 void
 MCRWWLockWriter2Enqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_wr2lock(object:%lu) (wait)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwwlock_wr2lock(rwwl:%u) (wait)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
@@ -101,6 +101,7 @@ MCRWWLockWriter2Lock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockWriter2Lock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wr2lock(object:%lu) (lock)\n",
-         this->thread->tid, this->rwwlock->getObjectId());
+  printf("thread %lu: pthread_rwlock_wr2lock(rwwl:%u) (lock)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/semaphore/MCSemEnqueue.cpp
+++ b/src/transitions/semaphore/MCSemEnqueue.cpp
@@ -91,6 +91,7 @@ MCSemEnqueue::dependentWith(const MCTransition *other) const
 void
 MCSemEnqueue::print() const
 {
-  printf("thread %lu: sem_wait(object:%lu) (awake -> asleep)\n",
-         this->thread->tid, this->sem->getObjectId());
+  printf("thread %lu: sem_wait(sem:%u) (awake -> asleep)\n",
+         this->thread->tid,
+         countVisibleObjectsOfType(this->sem->getObjectId()));
 }

--- a/src/transitions/semaphore/MCSemInit.cpp
+++ b/src/transitions/semaphore/MCSemInit.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/semaphore/MCSemInit.h"
+#include "mcmini/mcmini_private.h"
 
 MCTransition *
 MCReadSemInit(const MCSharedTransition *shmTransition, void *shmData,
@@ -69,6 +70,7 @@ MCSemInit::dependentWith(const MCTransition *other) const
 void
 MCSemInit::print() const
 {
-  printf("thread %lu: sem_init(object:%lu, 0, %u)\n", this->thread->tid,
-         this->sem->getObjectId(), this->sem->getCount());
+  printf("thread %lu: sem_init(sem:%u, 0, %u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->sem->getObjectId()),
+         this->sem->getCount());
 }

--- a/src/transitions/semaphore/MCSemPost.cpp
+++ b/src/transitions/semaphore/MCSemPost.cpp
@@ -75,6 +75,6 @@ MCSemPost::dependentWith(const MCTransition *other) const
 void
 MCSemPost::print() const
 {
-  printf("thread %lu: sem_post(object:%lu)\n", this->thread->tid,
-         this->sem->getObjectId());
+  printf("thread %lu: sem_post(sem:%u)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->sem->getObjectId()));
 }

--- a/src/transitions/semaphore/MCSemWait.cpp
+++ b/src/transitions/semaphore/MCSemWait.cpp
@@ -89,6 +89,6 @@ MCSemWait::enabledInState(const MCStack *) const
 void
 MCSemWait::print() const
 {
-  printf("thread %lu: sem_wait(object:%lu) (asleep -> awake)\n",
-         this->thread->tid, this->sem->getObjectId());
+  printf("thread %lu: sem_wait(sem:%u) (asleep -> awake)\n", this->thread->tid,
+         countVisibleObjectsOfType(this->sem->getObjectId()));
 }

--- a/src/transitions/threads/MCThreadCreate.cpp
+++ b/src/transitions/threads/MCThreadCreate.cpp
@@ -95,6 +95,6 @@ MCThreadCreate::doesCreateThread(tid_t tid) const
 void
 MCThreadCreate::print() const
 {
-  printf("thread %lu: pthread_create(%lu)\n", this->thread->tid,
+  printf("thread %lu: pthread_create(thr:%lu, _, _, _)\n", this->thread->tid,
          this->target->tid);
 }

--- a/src/transitions/threads/MCThreadJoin.cpp
+++ b/src/transitions/threads/MCThreadJoin.cpp
@@ -115,6 +115,6 @@ MCThreadJoin::joinsOnThread(
 void
 MCThreadJoin::print() const
 {
-  printf("thread %lu: pthread_join(%lu, _)\n", this->thread->tid,
+  printf("thread %lu: pthread_join(thr:%lu, _)\n", this->thread->tid,
          this->target->tid);
 }


### PR DESCRIPTION
print `visibleOperationId(this->mutex->getObjectId())`, not `this->mutex->getObjectId()`       (in the case of `mutex`)    
  * For example, print mut:1, sem:1, instead of object:1, object:2  

This translates objectId to operationId for a mutex for MCMutexLock,
We have replaced all cases of `object:XX` to the operation type.

Note that we were forced to add `#include <mcmini_private.h>` in many files.
Probably, we should re-factor how `mcmini_private.h` gets included.

We should also review how where we print `(enqueue)` for barriers, but `(awake -> asleep)` for semaphores and cond.