### PR TITLE
Recognize PTHREAD_MUTEX/COND/RWLOCK_INITIALIZER

### DIFF
--- a/include/mcmini/MCObjectStore.h
+++ b/include/mcmini/MCObjectStore.h
@@ -29,6 +29,12 @@ struct PointersEqual {
  * since the object's creation
  */
 class MCObjectStore {
+public:
+
+  inline std::shared_ptr<MCVisibleObject> getObjectWithId(objid_t objectId) {
+    return storage[objectId]->current;
+  }
+
 private:
 
   /**

--- a/include/mcmini/MCStack.h
+++ b/include/mcmini/MCStack.h
@@ -42,6 +42,9 @@ typedef MCTransition *(*MCSharedMemoryHandler)(
  * up into more manageable chunks
  */
 class MCStack {
+public:
+  std::shared_ptr<MCVisibleObject> getObjectWithId(objid_t);
+
 private:
 
   /**

--- a/include/mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp
+++ b/include/mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp
@@ -6,8 +6,9 @@
 namespace mcmini {
 
 struct ConditionVariableArbitraryPolicy :
-  public ConditionVariableSingleGroupPolicy {
+       public ConditionVariableSingleGroupPolicy {
   virtual void receive_signal_message() override;
+  virtual bool has_waiters() const override;
   std::unique_ptr<ConditionVariablePolicy> clone() const override;
 };
 

--- a/include/mcmini/misc/cond/MCConditionVariableDefaultPolicy.hpp
+++ b/include/mcmini/misc/cond/MCConditionVariableDefaultPolicy.hpp
@@ -22,6 +22,7 @@ struct ConditionVariableDefaultPolicy :
   virtual void receive_broadcast_message() override;
   virtual bool thread_can_exit(tid_t tid) const override;
   virtual void wake_thread(tid_t tid) override;
+  virtual bool has_waiters() const;
 
 protected:
 

--- a/include/mcmini/misc/cond/MCConditionVariableGLibcPolicy.hpp
+++ b/include/mcmini/misc/cond/MCConditionVariableGLibcPolicy.hpp
@@ -14,6 +14,7 @@ struct ConditionVariableGLibcPolicy :
   virtual void receive_broadcast_message() override;
   virtual void wake_thread(tid_t tid) override;
   virtual void add_waiter(tid_t tid) override;
+  virtual bool has_waiters() const override;
   std::unique_ptr<ConditionVariablePolicy> clone() const override;
 
 private:

--- a/include/mcmini/misc/cond/MCConditionVariablePolicy.hpp
+++ b/include/mcmini/misc/cond/MCConditionVariablePolicy.hpp
@@ -116,6 +116,8 @@ public:
    */
   virtual void add_waiter(tid_t tid) = 0;
 
+  virtual bool has_waiters() const = 0;
+
   virtual std::unique_ptr<ConditionVariablePolicy> clone() const = 0;
 
   virtual ~ConditionVariablePolicy() = default;

--- a/include/mcmini/misc/cond/MCConditionVariableSingleGroupPolicy.hpp
+++ b/include/mcmini/misc/cond/MCConditionVariableSingleGroupPolicy.hpp
@@ -13,6 +13,7 @@ struct ConditionVariableSingleGroupPolicy :
   virtual void receive_broadcast_message() override;
   virtual void wake_thread(tid_t tid) override;
   virtual void add_waiter(tid_t tid) override;
+  virtual bool has_waiters() const override;
 
 protected:
 

--- a/include/mcmini/objects/MCConditionVariable.h
+++ b/include/mcmini/objects/MCConditionVariable.h
@@ -54,8 +54,9 @@ public:
   // This value may be NULL before the condition variable has received
   // a pthread_cond_wait call
   //
-  // Note it is undefined to access a single condition variable with
-  // two different locks
+  // NOTE:  See MCCondWait.cpp:MCCondWait::applyToState() for a
+  //   comment on a single condition variable being successively
+  //   bound to two different mutexes.
   std::shared_ptr<MCMutex> mutex;
 
   ConditionVariable(Shadow shadow,
@@ -90,6 +91,7 @@ public:
   void destroy();
 
   void addWaiter(tid_t tid);
+  bool hasWaiters();
   void removeWaiter(tid_t tid);
   bool waiterCanExit(tid_t tid);
   void sendSignalMessage();

--- a/include/mcmini/objects/MCConditionVariable.h
+++ b/include/mcmini/objects/MCConditionVariable.h
@@ -35,9 +35,12 @@ public:
     explicit Shadow(pthread_cond_t *cond) : cond(cond) {}
   };
 
+  // `FIXME:  This used to be private.  But MCReadCondSignal, etc.,
+  //          needs to set shadow.state to 'initialized'.
+  Shadow shadow;
+
 private:
 
-  Shadow shadow;
   unsigned int numRemainingSpuriousWakeups = 0;
   std::unique_ptr<ConditionVariablePolicy> policy;
 

--- a/include/mcmini/objects/MCMutex.h
+++ b/include/mcmini/objects/MCMutex.h
@@ -13,8 +13,11 @@ struct MCMutexShadow {
 };
 
 struct MCMutex : public MCVisibleObject {
-private:
+public:
 
+  // FIXME:  This was private, but we need to access the state
+  //           in MCReadMutexLock().
+  //         Maybe add a method to directly access and modify the state?
   MCMutexShadow mutexShadow;
 
 public:

--- a/include/mcmini/objects/MCRWLock.h
+++ b/include/mcmini/objects/MCRWLock.h
@@ -23,9 +23,14 @@ struct MCRWLockShadow {
 };
 
 struct MCRWLock : public MCVisibleObject {
+public:
+
+  // FIXME:  This was private, but we need to access the state
+  //           in MCReadRWLockReaderLock()
+  MCRWLockShadow shadow;
+
 private:
 
-  MCRWLockShadow shadow;
   MCOptional<tid_t> active_writer = MCOptional<tid_t>::nil();
   std::vector<tid_t> active_readers;
 

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -865,6 +865,11 @@ MCStack::registerVisibleObjectWithSystemIdentity(
   this->objectStorage.mapSystemAddressToShadow(systemId, id);
 }
 
+std::shared_ptr<MCVisibleObject>
+MCStack::getObjectWithId(objid_t objectId) {
+  return objectStorage.getObjectWithId(objectId);
+}
+
 void
 MCStack::printThreadSchedule() const
 {

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -228,8 +228,8 @@ mc_create_global_state_object()
 int countVisibleObjectsOfType(int objectId) {
   int count = 0;
   for (int i = 0; i <= objectId; i++) {
-    if (typeid(programState->getTransitionAtIndex(i)) ==
-        typeid(programState->getTransitionAtIndex(objectId))) {
+    if (typeid(*(programState->getObjectWithId(i))) ==
+        typeid(*(programState->getObjectWithId(objectId)))) {
       count++;
     }
   }

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -636,12 +636,12 @@ mc_report_undefined_behavior(const char *msg)
   mc_terminate_trace();
   fprintf(stderr,
           "\n"
-          "Undefined Behavior Detected! \t\n"
-          "............................ \t\n"
-          "mcmini aborted the execution of trace with traceId %lu because\t\n"
-          "it detected undefined behavior\t\n"
+          "Undefined or Illegal Behavior Detected!\n"
+          "............................\n"
+          "mcmini aborted the execution of trace with traceId %lu because\n"
+          "it detected undefined behavior\n"
           "............................ \n"
-          "Reason: %s \t\n\n",
+          "Reason: %s\n\n",
           traceId, msg);
   programState->printTransitionStack();
   programState->printNextTransitions();

--- a/src/misc/cond/MCConditionVariableArbitraryPolicy.cpp
+++ b/src/misc/cond/MCConditionVariableArbitraryPolicy.cpp
@@ -20,4 +20,10 @@ ConditionVariableArbitraryPolicy::receive_signal_message()
   }
 }
 
+bool
+ConditionVariableArbitraryPolicy::has_waiters() const
+{
+  return ! this->wait_queue.empty();
+}
+
 } // namespace mcmini

--- a/src/misc/cond/MCConditionVariableDefaultPolicy.cpp
+++ b/src/misc/cond/MCConditionVariableDefaultPolicy.cpp
@@ -18,6 +18,16 @@ ConditionVariableDefaultPolicy::receive_broadcast_message()
 }
 
 bool
+ConditionVariableDefaultPolicy::has_waiters() const
+{
+  // broadcast_eligiblle_threads are those threads that were
+  //   blocked, but were around during the last broadcast.
+  // wake_groups are the groups that are available to wake.
+  return ! this->broadcast_eligible_threads.empty() ||
+         ! this->wake_groups.empty();
+}
+
+bool
 ConditionVariableDefaultPolicy::thread_can_exit(tid_t tid) const
 {
   // Either you're eligible to wake up because:

--- a/src/misc/cond/MCConditionVariableGLibcPolicy.cpp
+++ b/src/misc/cond/MCConditionVariableGLibcPolicy.cpp
@@ -75,6 +75,13 @@ ConditionVariableGLibcPolicy::add_waiter(tid_t tid)
   this->group2.push_back(tid);
 }
 
+
+bool
+ConditionVariableGLibcPolicy::has_waiters() const
+{
+  return !group1.empty() || !group2.empty();
+}
+
 std::unique_ptr<ConditionVariablePolicy>
 ConditionVariableGLibcPolicy::clone() const
 {

--- a/src/misc/cond/MCConditionVariableSingleGroupPolicy.cpp
+++ b/src/misc/cond/MCConditionVariableSingleGroupPolicy.cpp
@@ -39,4 +39,10 @@ ConditionVariableSingleGroupPolicy::add_waiter(tid_t tid)
   this->wait_queue.push_back(tid);
 }
 
+bool
+ConditionVariableSingleGroupPolicy::has_waiters() const
+{
+  return ! this->wait_queue.empty();
+}
+
 } // namespace mcmini

--- a/src/objects/MCConditionVariable.cpp
+++ b/src/objects/MCConditionVariable.cpp
@@ -52,6 +52,12 @@ MCConditionVariable::addWaiter(tid_t tid)
   this->policy->add_waiter(tid);
 }
 
+bool
+MCConditionVariable::hasWaiters()
+{
+  return this->policy->has_waiters();
+}
+
 void
 MCConditionVariable::removeWaiter(tid_t tid)
 {

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -1,20 +1,97 @@
 #include "mcmini/transitions/cond/MCCondBroadcast.h"
-#include "mcmini/mcmini_private.h"
+#include "mcmini/mcmini_private.h" /* For trace_pid, and state */
 #include "mcmini/transitions/mutex/MCMutexTransition.h"
+#include "mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp"
+#include <pthread.h>
+#include <string.h>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 MCTransition *
 MCReadCondBroadcast(const MCSharedTransition *shmTransition,
                     void *shmData, MCStack *state)
 {
-  const auto condInShm    = static_cast<pthread_cond_t **>(shmData);
-  const auto condSystemId = (MCSystemID)*condInShm;
-  const auto condThatExists =
+  // WAS: const MCSystemID condSystemId = *condInShm; condInShm=shmData;
+  pthread_cond_t * condSystemId = *static_cast<pthread_cond_t **>(shmData);
+  // We can't freeze this as 'const', since we might have to init cond later.
+  auto condThatExists =
     state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
       condSystemId);
 
-  MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
-    condThatExists != nullptr, "Attempting to signal a condition "
-                               "variable that is uninitialized");
+  bool testIfValidCond = false;
+  // SEE:  src/transitions/cond/MCCondInit.cpp:MCReadCondInit()
+  if (condThatExists == nullptr) {
+    auto shadow = MCConditionVariable::Shadow(condSystemId);
+    // If this has state 'undefined', then the condThatExists is still 'NULL'
+    if (shadow.state == MCConditionVariable::Shadow::undefined) {
+      testIfValidCond = true;
+    }
+    // FIXME: Allow dynamic selection of wakeup policies.
+    // For now, we hard-code it here. Not great, but at least
+    // we can change it relatively easily still
+
+    // FIXME:  We're assigning a condition variable policy of arbitrary.
+    //         Is this reasonable?
+    auto policy = std::unique_ptr<mcmini::ConditionVariablePolicy>(
+      new mcmini::ConditionVariableArbitraryPolicy());
+
+    auto newCond =
+      std::make_shared<mcmini::ConditionVariable>(shadow, std::move(policy));
+    // Then create and register an MCConditionVariable object.
+    state->registerVisibleObjectWithSystemIdentity(condSystemId, newCond);
+    // condThatExists =
+    //   std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
+    //     newCond);
+    // Get the current cond var on the stack, along with condSystemIdentity
+    //   (the pthread_cond_t struct of the user).
+    condThatExists =
+      state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
+        condSystemId);
+    // This is still MCConditionVariable::Shadow::undefined;
+    // We set that in the next 'if' statement.
+  }
+
+  assert(condThatExists != nullptr);
+
+  if (testIfValidCond || condThatExists -> shadow.state ==
+                         MCConditionVariable::Shadow::undefined) {
+#ifdef HAS_PROCESS_VM
+    pthread_cond_t cond_initializer = PTHREAD_COND_INITIALIZER;
+    // NOTE:  If PTHREAD_COND_INITIALIZER was used on a global variable,
+    //        the macro is all zeros, and the data segment is all zeros.
+    //        So, we can't tell if the initializer was or was not used.
+    //          But if a local variable of type pthread_cond_t is not
+    //        not initialized with PTHREAD_COND_INITIALIZER, and was
+    //        not initialized with pthread_cond_init, then this code can
+    //        truly catch an error.  pthread_cond_signal() would return
+    //        error "Illegal argument", but only if the user had checked
+    //        the return value of pthread_cond_signal, and then the errno.
+    pthread_cond_t local_cond;
+    struct iovec iov_remote_cond =
+      { .iov_base = condSystemId, .iov_len = sizeof(cond_initializer) };
+    struct iovec iov_local_cond =
+      { .iov_base = &local_cond, .iov_len = sizeof(cond_initializer) };
+    process_vm_readv(trace_pid, &iov_local_cond, 1, &iov_remote_cond, 1, 0);
+    if (memcmp(&local_cond, &cond_initializer, sizeof(cond_initializer)) != 0) {
+      mcprintf("\n*** ERROR (pthread_cond_broadcast/traceId: %d): The cond var\n"
+               "***     was never initialized.\n"
+               "***   Use pthread_cond_init() or PTHREAD_COND_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+#endif
+    if (condThatExists -> shadow.state ==
+        MCConditionVariable::Shadow::undefined) {
+      condThatExists -> shadow.state = MCConditionVariable::Shadow::initialized;
+    }
+  }
+
+  assert(condThatExists -> shadow.state ==
+           MCConditionVariable::Shadow::initialized ||
+         condThatExists -> shadow.state ==
+           MCConditionVariable::Shadow::destroyed);
+
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     !condThatExists->isDestroyed(),
     "Attempting to signal a destroyed condition variable");

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -3,22 +3,96 @@
 #include "mcmini/mcmini_private.h"
 #include "mcmini/transitions/mutex/MCMutexTransition.h"
 #include "mcmini/transitions/mutex/MCMutexUnlock.h"
+#include "mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp"
+#include <pthread.h>
+#include <string.h>
 
 MCTransition *
 MCReadCondEnqueue(const MCSharedTransition *shmTransition,
                   void *shmData, MCStack *state)
 {
+  // FIXME:  MCCondSignal.cpp does:
+  //       const auto condInShm    = static_cast<pthread_cond_t **>(shmData);
+  //   Shouldn't we do it that way also here, instead of
+  //   hiding the design with 'auto'?  - Gene
   const auto shmCond =
     static_cast<MCSharedMemoryConditionVariable *>(shmData);
   const auto condInShm     = shmCond->cond;
   const auto mutexInShm    = shmCond->mutex;
   const auto condSystemId  = (MCSystemID)condInShm;
   const auto mutexSystemId = (MCSystemID)mutexInShm;
-  const auto condThatExists =
+  // We can't freeze this as 'const', since we might nave to init cond later.
+  auto condThatExists =
     state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
       condSystemId);
   const auto mutexThatExists =
     state->getVisibleObjectWithSystemIdentity<MCMutex>(mutexSystemId);
+
+  /*** BAD DESIGN:
+   *** McMini has two state variables:  MCStack and mcmini::ConditionVariable::Shadow;.state
+   ***   where using MCConditionVariableShadow = mcmini::ConditionVariable::Shadow
+   *** (You can distinguish them by observinnmg that one uses thpe 'auto' and the other uses tyhpe 'auto'.
+   ***  You just havve to figure out nhhow the two non-equal thpes 'auto' are different.)
+   *** McMmini has two condIn Shm:
+   ***  condInShm2 = static_cast<pthread_cond_t **>(shmData); and condInShm = shmCond->cond;
+   *** (You can distinguish them by observinnmg that one uses thpe 'auto' and the other uses tyhpe 'auto'.
+   ***  You just havve to figure out nhhow the two non-equal thpes 'auto' are different.)
+   ***/
+  // *** We imitate the spaghetti code here, to get down to the 'state' for ConmInit (not CondEnqueue).
+  // *** The XXX2 variables are taken from MCCondinit,cpp (same dir);  XXX2 is used to avoid name conflicts
+  auto condInShm2 = static_cast<pthread_cond_t **>(shmData);
+  auto systemId2  = (MCSystemID)*condInShm2;
+  auto shadow2 = MCConditionVariableShadow(*condInShm2);
+  auto state2 = shadow2.state;
+
+  /*** BAD DESIGN:  mutexInShm->state works; but condInShm->state fails.
+   ***              The code cleverly uses 'auto' to make sure that
+   ***              developers can never be sure about what are the
+   ***              the types for mutexInShm and condInShm.
+   ***              This is the principle of 'data hiding' in OOD.  :-)
+   ***              So, the design rule seems to be: don't extend
+   ***              any code to support 'cond'.
+   ***  We want:  MCConditionVariable->shadow.state, but by using the
+   ***            the principle of 'data hiding', we use 'auto' to make
+   ***            sure that it's impossible to decide which of
+   ***            these variables has that type.
+   ***/
+  if (state2 == MCConditionVariableShadow::undefined) {
+    // Then create and register an MCConditionVariable object.
+    pthread_cond_t cond_initializer = PTHREAD_COND_INITIALIZER;
+    // mutexinShm->systemIdentity, but condInShm already means 'pthread_cond_t *'
+    // (Weird!  Why create a special type for 'pthread_cond_t *' ?)
+    if (memcmp(condInShm, &cond_initializer,
+               sizeof(cond_initializer)) != 0) {
+      memcpy(condInShm, &cond_initializer,
+             sizeof(cond_initializer));
+      mcprintf("WARNING: A mutex wasn't initialized by pthread_cond_init()\n"
+               "* We are initializing it now to PTHREAD_COND_INITIALIZER\n"
+               "* You can ignore this if target code also initialized it to\n"
+               "*   PTHREAD_COND_INITIALIZER\n");
+    }
+
+    // SEE:  src/transitions/cond/MCCondInit.cpp:MCReadCondInit()
+    if (condThatExists == nullptr) {
+      auto shadow = MCConditionVariableShadow(*condInShm2);
+
+      // FIXME: Allow dynamic selection of wakeup policies.
+      // For now, we hard-code it here. Not great, but at least
+      // we can change it relatively easily still
+
+      // FIXME:  We're assigning a condition variable policy of arbitrary.
+      //         Is tnhis reasonable?
+      auto policy = std::unique_ptr<mcmini::ConditionVariablePolicy>(
+        new mcmini::ConditionVariableArbitraryPolicy());
+
+      auto newCond =
+        std::make_shared<mcmini::ConditionVariable>(shadow, std::move(policy));
+      state->registerVisibleObjectWithSystemIdentity(systemId2, newCond);
+      condThatExists =
+        std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
+          newCond);
+    }
+  }
 
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     condThatExists != nullptr, "Attempting to wait on a condition "
@@ -31,6 +105,7 @@ MCReadCondEnqueue(const MCSharedTransition *shmTransition,
     mutexThatExists->isLocked(),
     "Attempting to wait on a condition variable with a "
     "mutex that is already unlocked.");
+  // FIXME:  This stmt is repeated below.  Shouldn't we delete his one? - Gene
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     !condThatExists->isDestroyed(),
     "Attempting to wait on a destroyed condition variable.");

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -1,111 +1,109 @@
 #include "mcmini/transitions/cond/MCCondEnqueue.h"
 #include "mcmini/MCTransitionFactory.h"
-#include "mcmini/mcmini_private.h"
+#include "mcmini/mcmini_private.h" /* For trace_pid, and state */
 #include "mcmini/transitions/mutex/MCMutexTransition.h"
 #include "mcmini/transitions/mutex/MCMutexUnlock.h"
 #include "mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp"
 #include <pthread.h>
 #include <string.h>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 MCTransition *
 MCReadCondEnqueue(const MCSharedTransition *shmTransition,
                   void *shmData, MCStack *state)
 {
-  // FIXME:  MCCondSignal.cpp does:
-  //       const auto condInShm    = static_cast<pthread_cond_t **>(shmData);
-  //   Shouldn't we do it that way also here, instead of
-  //   hiding the design with 'auto'?  - Gene
-  const auto shmCond =
-    static_cast<MCSharedMemoryConditionVariable *>(shmData);
-  const auto condInShm     = shmCond->cond;
-  const auto mutexInShm    = shmCond->mutex;
-  const auto condSystemId  = (MCSystemID)condInShm;
-  const auto mutexSystemId = (MCSystemID)mutexInShm;
-  // We can't freeze this as 'const', since we might nave to init cond later.
+  // WAS: const MCSystemID condSystemId = *condInShm; condInShm=shmData;
+  pthread_cond_t * condSystemId = *static_cast<pthread_cond_t **>(shmData);
+  // WAS: const auto mutexSystemId = (MCSystemID)mutexInShm;
+  auto shmCond = static_cast<MCSharedMemoryConditionVariable *>(shmData);
+  const auto mutexSystemId = (MCSystemID)shmCond->mutex;
+  const auto mutexThatExists =
+    state->getVisibleObjectWithSystemIdentity<MCMutex>(mutexSystemId);
+  // We can't freeze this as 'const', since we might have to init cond later.
   auto condThatExists =
     state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
       condSystemId);
-  const auto mutexThatExists =
-    state->getVisibleObjectWithSystemIdentity<MCMutex>(mutexSystemId);
 
-  /*** BAD DESIGN:
-   *** McMini has two state variables:  MCStack and mcmini::ConditionVariable::Shadow;.state
-   ***   where using MCConditionVariableShadow = mcmini::ConditionVariable::Shadow
-   *** (You can distinguish them by observinnmg that one uses thpe 'auto' and the other uses tyhpe 'auto'.
-   ***  You just havve to figure out nhhow the two non-equal thpes 'auto' are different.)
-   *** McMmini has two condIn Shm:
-   ***  condInShm2 = static_cast<pthread_cond_t **>(shmData); and condInShm = shmCond->cond;
-   *** (You can distinguish them by observinnmg that one uses thpe 'auto' and the other uses tyhpe 'auto'.
-   ***  You just havve to figure out nhhow the two non-equal thpes 'auto' are different.)
-   ***/
-  // *** We imitate the spaghetti code here, to get down to the 'state' for ConmInit (not CondEnqueue).
-  // *** The XXX2 variables are taken from MCCondinit,cpp (same dir);  XXX2 is used to avoid name conflicts
-  auto condInShm2 = static_cast<pthread_cond_t **>(shmData);
-  auto systemId2  = (MCSystemID)*condInShm2;
-  auto shadow2 = MCConditionVariableShadow(*condInShm2);
-  auto state2 = shadow2.state;
-
-  /*** BAD DESIGN:  mutexInShm->state works; but condInShm->state fails.
-   ***              The code cleverly uses 'auto' to make sure that
-   ***              developers can never be sure about what are the
-   ***              the types for mutexInShm and condInShm.
-   ***              This is the principle of 'data hiding' in OOD.  :-)
-   ***              So, the design rule seems to be: don't extend
-   ***              any code to support 'cond'.
-   ***  We want:  MCConditionVariable->shadow.state, but by using the
-   ***            the principle of 'data hiding', we use 'auto' to make
-   ***            sure that it's impossible to decide which of
-   ***            these variables has that type.
-   ***/
-  if (state2 == MCConditionVariableShadow::undefined) {
-    // Then create and register an MCConditionVariable object.
-    pthread_cond_t cond_initializer = PTHREAD_COND_INITIALIZER;
-    // mutexinShm->systemIdentity, but condInShm already means 'pthread_cond_t *'
-    // (Weird!  Why create a special type for 'pthread_cond_t *' ?)
-    if (memcmp(condInShm, &cond_initializer,
-               sizeof(cond_initializer)) != 0) {
-      memcpy(condInShm, &cond_initializer,
-             sizeof(cond_initializer));
-      mcprintf("WARNING: A mutex wasn't initialized by pthread_cond_init()\n"
-               "* We are initializing it now to PTHREAD_COND_INITIALIZER\n"
-               "* You can ignore this if target code also initialized it to\n"
-               "*   PTHREAD_COND_INITIALIZER\n");
+  bool testIfValidCond = false;
+  // SEE:  src/transitions/cond/MCCondInit.cpp:MCReadCondInit()
+  if (condThatExists == nullptr) {
+    auto shadow = MCConditionVariable::Shadow(condSystemId);
+    // If this has state 'undefined', then the condThatExists is still 'NULL'
+    if (shadow.state == MCConditionVariable::Shadow::undefined) {
+      testIfValidCond = true;
     }
+    // FIXME: Allow dynamic selection of wakeup policies.
+    // For now, we hard-code it here. Not great, but at least
+    // we can change it relatively easily still
 
-    // SEE:  src/transitions/cond/MCCondInit.cpp:MCReadCondInit()
-    if (condThatExists == nullptr) {
-      auto shadow = MCConditionVariableShadow(*condInShm2);
+    // FIXME:  We're assigning a condition variable policy of arbitrary.
+    //         Is this reasonable?
+    auto policy = std::unique_ptr<mcmini::ConditionVariablePolicy>(
+      new mcmini::ConditionVariableArbitraryPolicy());
 
-      // FIXME: Allow dynamic selection of wakeup policies.
-      // For now, we hard-code it here. Not great, but at least
-      // we can change it relatively easily still
+    auto newCond =
+      std::make_shared<mcmini::ConditionVariable>(shadow, std::move(policy));
+    // Then create and register an MCConditionVariable object.
+    state->registerVisibleObjectWithSystemIdentity(condSystemId, newCond);
+    // condThatExists =
+    //   std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
+    //     newCond);
+    // Get the current cond var on the stack, along with condSystemIdentity
+    //   (the pthread_cond_t struct of the user).
+    condThatExists =
+      state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
+        condSystemId);
+    // This is still MCConditionVariable::Shadow::undefined;
+    // We set that in the next 'if' statement.
+  }
 
-      // FIXME:  We're assigning a condition variable policy of arbitrary.
-      //         Is tnhis reasonable?
-      auto policy = std::unique_ptr<mcmini::ConditionVariablePolicy>(
-        new mcmini::ConditionVariableArbitraryPolicy());
+  assert(condThatExists != nullptr);
+  assert(mutexThatExists != nullptr);
 
-      auto newCond =
-        std::make_shared<mcmini::ConditionVariable>(shadow, std::move(policy));
-      state->registerVisibleObjectWithSystemIdentity(systemId2, newCond);
-      condThatExists =
-        std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
-          newCond);
+  if (testIfValidCond || condThatExists -> shadow.state ==
+                         MCConditionVariable::Shadow::undefined) {
+#ifdef HAS_PROCESS_VM
+    pthread_cond_t cond_initializer = PTHREAD_COND_INITIALIZER;
+    // NOTE:  If PTHREAD_COND_INITIALIZER was used on a global variable,
+    //        the macro is all zeros, and the data segment is all zeros.
+    //        So, we can't tell if the initializer was or was not used.
+    //          But if a local variable of type pthread_cond_t is not
+    //        not initialized with PTHREAD_COND_INITIALIZER, and was
+    //        not initialized with pthread_cond_init, then this code can
+    //        truly catch an error.  pthread_cond_signal() would return
+    //        error "Illegal argument", but only if the user had checked
+    //        the return value of pthread_cond_signal, and then the errno.
+    pthread_cond_t local_cond;
+    struct iovec iov_remote_cond =
+      { .iov_base = condSystemId, .iov_len = sizeof(cond_initializer) };
+    struct iovec iov_local_cond =
+      { .iov_base = &local_cond, .iov_len = sizeof(cond_initializer) };
+    process_vm_readv(trace_pid, &iov_local_cond, 1, &iov_remote_cond, 1, 0);
+    if (memcmp(&local_cond, &cond_initializer, sizeof(cond_initializer)) != 0) {
+      mcprintf("\n*** ERROR (pthread_cond_wait/traceId: %d): The cond var\n"
+               "***     was never initialized.\n"
+               "***   Use pthread_cond_init() or PTHREAD_COND_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+#endif
+    if (condThatExists -> shadow.state ==
+        MCConditionVariable::Shadow::undefined) {
+      condThatExists -> shadow.state = MCConditionVariable::Shadow::initialized;
     }
   }
 
-  MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
-    condThatExists != nullptr, "Attempting to wait on a condition "
-                               "variable that is uninitialized.");
-  MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
-    mutexThatExists != nullptr,
-    "Attempting to wait on a condition variable with an "
-    "uninitialized mutex.");
+  assert(condThatExists -> shadow.state ==
+           MCConditionVariable::Shadow::initialized ||
+         condThatExists -> shadow.state ==
+           MCConditionVariable::Shadow::destroyed);
+
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     mutexThatExists->isLocked(),
-    "Attempting to wait on a condition variable with a "
-    "mutex that is already unlocked.");
-  // FIXME:  This stmt is repeated below.  Shouldn't we delete his one? - Gene
+    "Attempting to wait on a condition variable with a mutex that is unlocked.");
+
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     !condThatExists->isDestroyed(),
     "Attempting to wait on a destroyed condition variable.");
@@ -117,9 +115,6 @@ MCReadCondEnqueue(const MCSharedTransition *shmTransition,
       "variable is undefined behavior. Ensure that you're calling\n"
       "pthread_cond_wait() with the same mutex.");
   }
-  MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
-    !condThatExists->isDestroyed(),
-    "Attempting to wait on a destroyed condition variable.");
 
   const auto threadThatRanId = shmTransition->executor;
   const auto mutexAssociatedWithConditionVariable =
@@ -129,13 +124,15 @@ MCReadCondEnqueue(const MCSharedTransition *shmTransition,
   // to NOT already be associated with a mutex at this point.
   // E.g., the first call to pthread_cond_wait() will have a
   // condition variable that isn't associated with a mutex.
+  //    mutexThatExists->mutexShadow.systemIdentity
   if (mutexAssociatedWithConditionVariable) {
     MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
       *mutexAssociatedWithConditionVariable == *mutexThatExists,
-      "A mutex has already been associated with this condition "
-      "variable. Attempting to wait on a condition variable using "
-      "more "
-      "than one mutex is undefined");
+      "A different mutex was previously bound to this condition variable,\n"
+      "and at least one thread is still blocked on that previous mutex.\n"
+      "But pthread_cond_wait is attempting to bind a new mutex to the\n"
+      "condition variable, even while some thread is still blocked on\n"
+      "the first mutex.");
   }
 
   // NOTE: We have to associate the mutex with the condition

--- a/src/transitions/cond/MCCondInit.cpp
+++ b/src/transitions/cond/MCCondInit.cpp
@@ -1,6 +1,9 @@
 #include "mcmini/transitions/cond/MCCondInit.h"
 #include "mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp"
 #include "mcmini/mcmini_private.h"
+#include <pthread.h>
+#include <string.h>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 using namespace std;
 using namespace mcmini;
@@ -9,29 +12,95 @@ MCTransition *
 MCReadCondInit(const MCSharedTransition *shmTransition, void *shmData,
                MCStack *state)
 {
-  auto condInShm = static_cast<pthread_cond_t **>(shmData);
-  auto systemId  = (MCSystemID)*condInShm;
+  // WAS: const MCSystemID condSystemId = *condInShm; condInShm=shmData;
+  pthread_cond_t * condSystemId = *static_cast<pthread_cond_t **>(shmData);
   auto condThatExists =
     state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
-      systemId);
+      condSystemId);
+
+  // SEE:  src/transitions/cond/MCCondInit.cpp:MCReadCondInit()
+  bool testIfValidCond = false;
 
   if (condThatExists == nullptr) {
-    auto shadow = MCConditionVariableShadow(*condInShm);
-
+    auto shadow = MCConditionVariableShadow(condSystemId);
+    // If this has state 'undefined', then the condThatExists is still 'NULL'
+    if (shadow.state == MCConditionVariable::Shadow::undefined) {
+      testIfValidCond = true;
+    }
     // FIXME: Allow dynamic selection of wakeup policies.
     // For now, we hard-code it here. Not great, but at least
     // we can change it relatively easily still
 
+    // FIXME:  We're assigning a condition variable policy of arbitrary.
+    //         Is this reasonable?
     auto policy = std::unique_ptr<ConditionVariablePolicy>(
       new ConditionVariableArbitraryPolicy());
 
     auto newCond =
       std::make_shared<ConditionVariable>(shadow, std::move(policy));
-    state->registerVisibleObjectWithSystemIdentity(systemId, newCond);
+    // Then create and register an MCConditionVariable object.
+    state->registerVisibleObjectWithSystemIdentity(condSystemId, newCond);
+    // condThatExists =
+    //   std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
+    //     newCond);
+    // Get the current cond var on the stack, along with condSystemIdentity
+    //   (the pthread_cond_t struct of the user).
     condThatExists =
-      std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
-        newCond);
+      state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
+        condSystemId);
+    // WAS: condThatExists =
+    //   std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
+    //     newCond);
+    // This is still MCConditionVariable::Shadow::undefined;
+    // We set that in the next 'if' statement.
   }
+
+  assert(condThatExists != nullptr);
+
+#if 1
+  if (testIfValidCond) {
+    condThatExists -> shadow.state = MCConditionVariable::Shadow::initialized;
+  }
+
+#else
+  // We know that user has pthread_cond_init.  So, we could remove this 'if'.
+  if (testIfValidCond || condThatExists -> shadow.state ==
+                         MCConditionVariable::Shadow::undefined) {
+    // Then create and register an MCConditionVariable object.
+    pthread_cond_t cond_initializer = PTHREAD_COND_INITIALIZER;
+    // NOTE:  If PTHREAD_COND_INITIALIZER was used on a global variable,
+    //        the macro is all zeros, and the data segment is all zeros.
+    //        So, we can't tell if the initializer was or was not used.
+    //          But if a local variable of type pthread_cond_t is not
+    //        not initialized with PTHREAD_COND_INITIALIZER, and was
+    //        not initialized with pthread_cond_init, then this code can
+    //        truly catch an error.  pthread_cond_signal() would return
+    //        error "Illegal argument", but only if the user had checked
+    //        the return value of pthread_cond_signal, and then the errno.
+    pthread_cond_t local_cond;
+    struct iovec iov_remote_cond =
+      { .iov_base = condSystemId, .iov_len = sizeof(cond_initializer) };
+    struct iovec iov_local_cond =
+      { .iov_base = &local_cond, .iov_len = sizeof(cond_initializer) };
+    process_vm_readv(trace_pid, &iov_local_cond, 1, &iov_remote_cond, 1, 0);
+    if (memcmp(&local_cond, &cond_initializer, sizeof(cond_initializer)) != 0) {
+      mcprintf("\n*** ERROR (pthread_cond_init/traceId: %d): The cond var\n"
+               "***     was never initialized.\n"
+               "***   Use pthread_cond_init() or PTHREAD_COND_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+    if (condThatExists -> shadow.state ==
+        MCConditionVariable::Shadow::undefined) {
+      condThatExists -> shadow.state = MCConditionVariable::Shadow::initialized;
+    }
+  }
+#endif
+
+  assert(condThatExists -> shadow.state ==
+         MCConditionVariable::Shadow::initialized);
 
   tid_t threadThatRanId = shmTransition->executor;
   auto threadThatRan    = state->getThreadWithId(threadThatRanId);

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -1,23 +1,103 @@
 #include "mcmini/transitions/cond/MCCondSignal.h"
-#include "mcmini/mcmini_private.h"
+#include "mcmini/mcmini_private.h" /* For trace_pid, and state */
 #include "mcmini/transitions/mutex/MCMutexTransition.h"
+#include "mcmini/misc/cond/MCConditionVariableArbitraryPolicy.hpp"
+#include <pthread.h>
+#include <string.h>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 MCTransition *
 MCReadCondSignal(const MCSharedTransition *shmTransition,
                  void *shmData, MCStack *state)
 {
-  const auto condInShm    = static_cast<pthread_cond_t **>(shmData);
-  const auto condSystemId = (MCSystemID)*condInShm;
-  const auto condThatExists =
+  // WAS: const MCSystemID condSystemId = *condInShm; condInShm=shmData;
+  pthread_cond_t * condSystemId = *static_cast<pthread_cond_t **>(shmData);
+  // We can't freeze this as 'const', since we might have to init cond later.
+  auto condThatExists =
     state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
       condSystemId);
 
-  MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
-    condThatExists != nullptr, "Attempting to signal a condition "
-                               "variable that is uninitialized");
+  bool testIfValidCond = false;
+  // SEE:  src/transitions/cond/MCCondInit.cpp:MCReadCondInit()
+  if (condThatExists == nullptr) {
+    auto shadow = MCConditionVariable::Shadow(condSystemId);
+    // If this has state 'undefined', then the condThatExists is still 'NULL'
+    if (shadow.state == MCConditionVariable::Shadow::undefined) {
+      testIfValidCond = true;
+    }
+    // FIXME: Allow dynamic selection of wakeup policies.
+    // For now, we hard-code it here. Not great, but at least
+    // we can change it relatively easily still
+
+    // FIXME:  We're assigning a condition variable policy of arbitrary.
+    //         Is this reasonable?
+    auto policy = std::unique_ptr<mcmini::ConditionVariablePolicy>(
+      new mcmini::ConditionVariableArbitraryPolicy());
+
+    auto newCond =
+      std::make_shared<mcmini::ConditionVariable>(shadow, std::move(policy));
+    // Then create and register an MCConditionVariable object.
+    state->registerVisibleObjectWithSystemIdentity(condSystemId, newCond);
+    // condThatExists =
+    //   std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(
+    //     newCond);
+    // Get the current cond var on the stack, along with condSystemIdentity
+    //   (the pthread_cond_t struct of the user).
+    condThatExists =
+      state->getVisibleObjectWithSystemIdentity<MCConditionVariable>(
+        condSystemId);
+#if 0
+    // This is an alternative.
+    condThatExists =
+      std::static_pointer_cast<MCConditionVariable, MCVisibleObject>(newCond);
+#endif
+    // This is still MCConditionVariable::Shadow::undefined;
+    // We set that in the next 'if' statement.
+  }
+
+  assert(condThatExists != nullptr);
+
+  if (testIfValidCond || condThatExists -> shadow.state ==
+                         MCConditionVariable::Shadow::undefined) {
+#ifdef HAS_PROCESS_VM
+    pthread_cond_t cond_initializer = PTHREAD_COND_INITIALIZER;
+    // NOTE:  If PTHREAD_COND_INITIALIZER was used on a global variable,
+    //        the macro is all zeros, and the data segment is all zeros.
+    //        So, we can't tell if the initializer was or was not used.
+    //          But if a local variable of type pthread_cond_t is not
+    //        not initialized with PTHREAD_COND_INITIALIZER, and was
+    //        not initialized with pthread_cond_init, then this code can
+    //        truly catch an error.  pthread_cond_signal() would return
+    //        error "Illegal argument", but only if the user had checked
+    //        the return value of pthread_cond_signal, and then the errno.
+    pthread_cond_t local_cond;
+    struct iovec iov_remote_cond =
+      { .iov_base = condSystemId, .iov_len = sizeof(cond_initializer) };
+    struct iovec iov_local_cond =
+      { .iov_base = &local_cond, .iov_len = sizeof(cond_initializer) };
+    process_vm_readv(trace_pid, &iov_local_cond, 1, &iov_remote_cond, 1, 0);
+    if (memcmp(&local_cond, &cond_initializer, sizeof(cond_initializer)) != 0) {
+      mcprintf("\n*** ERROR (pthread_cond_signal/traceId: %d): The cond var\n"
+               "***     was never initialized.\n"
+               "***   Use pthread_cond_init() or PTHREAD_COND_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+#endif
+    if (condThatExists -> shadow.state ==
+        MCConditionVariable::Shadow::undefined) {
+      condThatExists -> shadow.state = MCConditionVariable::Shadow::initialized;
+    }
+  }
+
+  assert(condThatExists -> shadow.state ==
+         MCConditionVariable::Shadow::initialized);
+
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     !condThatExists->isDestroyed(),
-    "Attempting to signal a destroyed condition variable");
+    "Attempting to broadcast to a destroyed condition variable");
 
   const auto threadThatRanId = shmTransition->executor;
   auto threadThatRan = state->getThreadWithId(threadThatRanId);

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -79,6 +79,12 @@ MCCondWait::applyToState(MCStack *state)
   const tid_t threadId = this->getThreadId();
   this->conditionVariable->mutex->lock(threadId);
   this->conditionVariable->removeWaiter(threadId);
+  // POSIX sttandard says that the dynamic binding of a condition variable
+  // to a mutex is removed when the last thread waiting on that cond var is
+  // unblocked (i.e., has re-acquired the associated mutex of the cond var).
+  if (! this->conditionVariable->hasWaiters()) {
+    this->conditionVariable->mutex = nullptr;
+  }
 }
 
 bool

--- a/src/transitions/mutex/MCMutexLock.cpp
+++ b/src/transitions/mutex/MCMutexLock.cpp
@@ -1,17 +1,84 @@
 #include "mcmini/transitions/mutex/MCMutexLock.h"
-#include "mcmini/mcmini_private.h"
 #include "mcmini/transitions/mutex/MCMutexUnlock.h"
 #include "mcmini/transitions/threads/MCThreadCreate.h"
+#include "mcmini/mcmini_private.h" /* For trace_pid, and state */
+#include <pthread.h>
+#include <string.h>
 #include <memory>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 MCTransition *
 MCReadMutexLock(const MCSharedTransition *shmTransition,
                 void *shmData, MCStack *state)
 {
   auto mutexInShm = static_cast<MCMutexShadow *>(shmData);
+
   auto mutexThatExists =
     state->getVisibleObjectWithSystemIdentity<MCMutex>(
-      (MCSystemID)mutexInShm->systemIdentity);
+             (MCSystemID)mutexInShm->systemIdentity);
+
+  // SEE:  src/transitions/mutex/MCMutexInit.cpp:MCReadMutexInit()
+  bool testIfValidMutex = false;
+  if (mutexThatExists == nullptr) {
+    auto newMutex = new MCMutex(*mutexInShm);
+    // If this has state 'undefined', then the mutexThatExists is still 'NULL'
+    if (newMutex->mutexShadow.state == MCMutexShadow::undefined) {
+      testIfValidMutex = true;
+    }
+    auto newMutexSharedPtr =
+      std::shared_ptr<MCVisibleObject>(newMutex);
+    // systemId is the pthread_mutex_t struct of the user).
+    auto systemId = (MCSystemID)mutexInShm->systemIdentity;
+    // This 'state' refers to 'MCStack' and not 'state' of mutex.
+    // Register the mutex on the stack.
+    state->registerVisibleObjectWithSystemIdentity(systemId,
+                                                   newMutexSharedPtr);
+    mutexThatExists =
+      state->getVisibleObjectWithSystemIdentity<MCMutex>(systemId);
+#if 0
+    // This is an alternative:
+    mutexThatExists =
+      std::static_pointer_cast<MCMutex, MCVisibleObject>(newMutexSharedPtr);
+#endif
+    // This is still MCMutexShadow::undefined;
+    // We set that in the next 'if' statement.
+  }
+
+  assert(mutexThatExists != nullptr);
+
+  // NOTE:  MCMutexShadow != MCMutex::Shadow ; unlike MCCondShadow
+  if (testIfValidMutex || mutexThatExists -> mutexShadow.state ==
+                          MCMutexShadow::undefined) {
+#ifdef HAS_PROCESS_VM
+    // NOTE:  If the mutex is in the data or heap segment, then it will be
+    // pre-initialized to all zero, which is same as PTHREAD_MUTEX_INITIALIZER.
+    // So, uninitialized mutex'es won't be detected in this situation.
+    pthread_mutex_t mutex_initializer = PTHREAD_MUTEX_INITIALIZER;
+    pthread_cond_t local_mut;
+    struct iovec iov_remote_mut =
+      { .iov_base = mutexInShm->systemIdentity,
+        .iov_len = sizeof(mutex_initializer) };
+    struct iovec iov_local_mut =
+      { .iov_base = &local_mut, .iov_len = sizeof(mutex_initializer) };
+    process_vm_readv(trace_pid, &iov_local_mut, 1, &iov_remote_mut, 1, 0);
+    if (memcmp(&local_mut, &mutex_initializer, sizeof(mutex_initializer)) != 0){
+      mcprintf("\n*** ERROR (pthread_mutex_lock/traceId: %d): The mutex was\n"
+               "***     never initialized.\n"
+               "***   Use pthread_mutex_init() or PTHREAD_MUTEX_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+#endif
+    if (mutexThatExists -> mutexShadow.state == MCMutexShadow::undefined) {
+      mutexThatExists -> mutexShadow.state = MCMutexShadow::unlocked;
+    }
+  }
+
+  // The mutex might have been locked or unlocked when this was called.
+  assert(mutexThatExists -> mutexShadow.state == MCMutexShadow::unlocked ||
+         mutexThatExists -> mutexShadow.state == MCMutexShadow::locked);
 
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     mutexThatExists != nullptr,

--- a/src/transitions/rwlock/MCRWLockInit.cpp
+++ b/src/transitions/rwlock/MCRWLockInit.cpp
@@ -18,6 +18,8 @@ MCReadRWLockInit(const MCSharedTransition *shmTransition,
     rwLock = newRWLock;
   }
 
+  rwLock -> shadow.state = MCRWLockShadow::State::unlocked;
+
   tid_t threadThatRanId = shmTransition->executor;
   auto threadThatRan    = state->getThreadWithId(threadThatRanId);
   return new MCRWLockInit(threadThatRan, rwLock);

--- a/src/transitions/rwlock/MCRWLockReaderLock.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderLock.cpp
@@ -1,15 +1,74 @@
 #include "mcmini/transitions/rwlock/MCRWLockReaderLock.h"
 #include "mcmini/mcmini_private.h"
 #include "mcmini/transitions/rwlock/MCRWLockWriterLock.h"
+#include <pthread.h>
+#include <string.h>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 MCTransition *
 MCReadRWLockReaderLock(const MCSharedTransition *shmTransition,
                        void *shmData, MCStack *state)
 {
-  auto rwlockInShm = static_cast<MCRWLockShadow *>(shmData);
-  auto systemId    = (MCSystemID)rwlockInShm->systemIdentity;
+  // SEE: src/transitions/rwlock/MCRWLockInit.cpp
+  // WAS: auto rwlockInShm = static_cast<MCRWLockShadow *>(shmData);
+  auto systemId =
+    (MCSystemID)static_cast<MCRWLockShadow *>(shmData)->systemIdentity;
+  // rwLock appears to be the analog of rwlockThatExists.
   auto rwLock =
     state->getVisibleObjectWithSystemIdentity<MCRWLock>(systemId);
+
+  bool testIfValidRwlock = false;
+  if (rwLock == nullptr) {
+    auto newRWLock = std::make_shared<MCRWLock>(
+      *static_cast<MCRWLockShadow *>(shmData), MCRWLock::Type::no_preference);
+    if (newRWLock->shadow.state == MCRWLockShadow::State::undefined) {
+      testIfValidRwlock = true;
+    }
+    // Then create and register an MCConditionVariable object.
+    state->registerVisibleObjectWithSystemIdentity(systemId,
+                                                   newRWLock);
+    rwLock = newRWLock;
+  }
+
+  assert(rwLock != nullptr);
+
+  if (testIfValidRwlock || rwLock->shadow.state ==
+                           MCRWLockShadow::State::undefined) {
+#ifdef HAS_PROCESS_VM
+    pthread_rwlock_t rwlock_initializer = PTHREAD_RWLOCK_INITIALIZER;
+    // NOTE:  If PTHREAD_RWLOCK_INITIALIZER was used on a global variable,
+    //        the macro is all zeros, and the data segment is all zeros.
+    //        So, we can't tell if the initializer was or was not used.
+    //          But if a local variable of type pthread_rwlock_t is not
+    //        not initialized with PTHREAD_RWLOCK_INITIALIZER, and was
+    //        not initialized with pthread_rwlock_init, then this code can
+    //        truly catch an error.  pthread_rwlock_rwlock() would return
+    //        error "Illegal argument", but only if the user had checked
+    //        the return value of pthread_rwloc_rdlock, and then the errno.
+    pthread_rwlock_t local_rwlock;
+    struct iovec iov_remote_rwlock =
+      { .iov_base = systemId, .iov_len = sizeof(rwlock_initializer) };
+    struct iovec iov_local_rwlock =
+      { .iov_base = &local_rwlock, .iov_len = sizeof(rwlock_initializer) };
+    process_vm_readv(trace_pid, &iov_local_rwlock, 1, &iov_remote_rwlock, 1, 0);
+    if (memcmp(&local_rwlock,
+               &rwlock_initializer, sizeof(rwlock_initializer)) != 0) {
+      mcprintf("\n*** ERROR (pthread_rwlock_rdlock/traceId: %d): The rwlock\n"
+               "***     was never initialized.\n"
+               "***   Use pthread_rwloc_init() or PTHREAD_RWLOCK_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+#endif
+    if (rwLock -> shadow.state ==
+        MCRWLockShadow::State::undefined) {
+      rwLock -> shadow.state = MCRWLockShadow::State::unlocked;
+    }
+  }
+
+  assert(rwLock -> shadow.state == MCRWLockShadow::State::unlocked);
 
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     rwLock != nullptr, "Attempting to lock an uninitialized rw-lock");

--- a/src/transitions/rwlock/MCRWLockWriterLock.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterLock.cpp
@@ -1,15 +1,74 @@
 #include "mcmini/transitions/rwlock/MCRWLockWriterLock.h"
 #include "mcmini/mcmini_private.h"
 #include "mcmini/transitions/rwlock/MCRWLockReaderLock.h"
+#include <pthread.h>
+#include <string.h>
+#include <sys/uio.h> /* For process_vm_readv() */
 
 MCTransition *
 MCReadRWLockWriterLock(const MCSharedTransition *shmTransition,
                        void *shmData, MCStack *state)
 {
-  auto rwlockInShm = static_cast<MCRWLockShadow *>(shmData);
-  auto systemId    = (MCSystemID)rwlockInShm->systemIdentity;
+  // SEE: src/transitions/rwlock/MCRWLockInit.cpp
+  // WAS: auto rwlockInShm = static_cast<MCRWLockShadow *>(shmData);
+  auto systemId =
+    (MCSystemID)static_cast<MCRWLockShadow *>(shmData)->systemIdentity;
+  // rwLock appears to be the analog of rwlockThatExists.
   auto rwLock =
     state->getVisibleObjectWithSystemIdentity<MCRWLock>(systemId);
+
+  bool testIfValidRwlock = false;
+  if (rwLock == nullptr) {
+    auto newRWLock = std::make_shared<MCRWLock>(
+      *static_cast<MCRWLockShadow *>(shmData), MCRWLock::Type::no_preference);
+    if (newRWLock->shadow.state == MCRWLockShadow::State::undefined) {
+      testIfValidRwlock = true;
+    }
+    // Then create and register an MCConditionVariable object.
+    state->registerVisibleObjectWithSystemIdentity(systemId,
+                                                   newRWLock);
+    rwLock = newRWLock;
+  }
+
+  assert(rwLock != nullptr);
+
+  if (testIfValidRwlock || rwLock->shadow.state ==
+                           MCRWLockShadow::State::undefined) {
+#ifdef HAS_PROCESS_VM
+    pthread_rwlock_t rwlock_initializer = PTHREAD_RWLOCK_INITIALIZER;
+    // NOTE:  If PTHREAD_RWLOCK_INITIALIZER was used on a global variable,
+    //        the macro is all zeros, and the data segment is all zeros.
+    //        So, we can't tell if the initializer was or was not used.
+    //          But if a local variable of type pthread_rwlock_t is not
+    //        not initialized with PTHREAD_RWLOCK_INITIALIZER, and was
+    //        not initialized with pthread_rwlock_init, then this code can
+    //        truly catch an error.  pthread_rwlock_rwlock() would return
+    //        error "Illegal argument", but only if the user had checked
+    //        the return value of pthread_rwloc_wrlock, and then the errno.
+    pthread_rwlock_t local_rwlock;
+    struct iovec iov_remote_rwlock =
+      { .iov_base = systemId, .iov_len = sizeof(rwlock_initializer) };
+    struct iovec iov_local_rwlock =
+      { .iov_base = &local_rwlock, .iov_len = sizeof(rwlock_initializer) };
+    process_vm_readv(trace_pid, &iov_local_rwlock, 1, &iov_remote_rwlock, 1, 0);
+    if (memcmp(&local_rwlock,
+               &rwlock_initializer, sizeof(rwlock_initializer)) != 0) {
+      mcprintf("\n*** ERROR (pthread_rwlock_wrlock/traceId: %d): The rwlock\n"
+               "***     was never initialized.\n"
+               "***   Use pthread_rwloc_init() or PTHREAD_RWLOCK_INITIALIZER.\n"
+               "***   Additional McMini traces will not work with this bug.\n"
+               "***   McMini is exiting now.\n\n", traceId);
+      // No need to patch it with process_vm_writev.  We will stop now.
+      mc_stop_model_checking(EXIT_FAILURE);
+    }
+#endif
+    if (rwLock -> shadow.state ==
+        MCRWLockShadow::State::undefined) {
+      rwLock -> shadow.state = MCRWLockShadow::State::unlocked;
+    }
+  }
+
+  assert(rwLock -> shadow.state == MCRWLockShadow::State::unlocked);
 
   MC_REPORT_UNDEFINED_BEHAVIOR_ON_FAIL(
     rwLock != nullptr, "Attempting to lock an uninitialized rw-lock");


### PR DESCRIPTION
This makes McMini support `PTHREAD_MUTEX_INITIALIZER`, `PTHREAD_COND_INITIALIZER` and  `PTHREAD_RWLOCK_INITIALIZER`.

***To the best of myknowledge, this is now ocmplete and bug-ffree.***

When it discovers `state == undefined`, it sets `state == initialized` (or `state == unlocked` for mutex), and also copies:
`PTHREAD_MUTEX_INITIALIZER`, `PTHREAD_COND_INITIALIZER`, and  `PTHREAD_RWLOCK_INITIALIZER` into the application's corresponding variables of type `pthread_mutex_t`, `pthread_cond_t`, and `pthread_rwlock_t`.

I have now removed my obnoxious comments.

1.  It would be nice to later do a new PR that cleans up things like changing 'auto' to the obvious type.
2.  Alternatively, we could copy this into your new McMini-v2, but that is probably not something that can be done quickly.