### PR TITLE
g++: -Wreorder and -Wclass-memaccess warnings fixed for .h files

### DIFF
--- a/include/mcmini/MCObjectStore.h
+++ b/include/mcmini/MCObjectStore.h
@@ -72,7 +72,9 @@ private:
 
 public:
 
-  inline MCObjectStore() { bzero(storage, sizeof(storage)); }
+  // NOTE:  This cast could be done in a more complicated C++ way:
+  //        https://stackoverflow.com/questions/66368061/error-clearing-an-object-of-non-trivial-type-with-memset
+  inline MCObjectStore() { memset((void *)storage, 0, sizeof(storage)); }
 
   inline objid_t
   registerNewObject(std::shared_ptr<MCVisibleObject> object)

--- a/include/mcmini/MCSharedTransition.h
+++ b/include/mcmini/MCSharedTransition.h
@@ -10,7 +10,7 @@ public:
   const std::type_info &type;
   tid_t executor;
   MCSharedTransition(tid_t executor, const std::type_info &type)
-    : executor(executor), type(type)
+    : type(type), executor(executor)
   {}
 };
 

--- a/include/mcmini/objects/MCConditionVariable.h
+++ b/include/mcmini/objects/MCConditionVariable.h
@@ -67,8 +67,9 @@ public:
 
   ConditionVariable(const ConditionVariable &cond)
     : MCVisibleObject(cond.getObjectId()), shadow(cond.shadow),
-      mutex(nullptr), policy(std::move(cond.policy->clone())),
-      numRemainingSpuriousWakeups(cond.numRemainingSpuriousWakeups)
+      numRemainingSpuriousWakeups(cond.numRemainingSpuriousWakeups),
+      policy(std::move(cond.policy->clone())),
+      mutex(nullptr)
   {
     if (cond.mutex != nullptr) {
       mutex = std::static_pointer_cast<MCMutex, MCVisibleObject>(

--- a/include/mcmini/objects/MCRWLock.h
+++ b/include/mcmini/objects/MCRWLock.h
@@ -50,11 +50,12 @@ public:
   {}
   inline MCRWLock(const MCRWLock &rwlock)
     : MCVisibleObject(rwlock.getObjectId()), shadow(rwlock.shadow),
-      type(rwlock.type), active_writer(rwlock.active_writer),
+      active_writer(rwlock.active_writer),
       active_readers(rwlock.active_readers),
       reader_queue(rwlock.reader_queue),
       writer_queue(rwlock.writer_queue),
-      acquire_queue(rwlock.acquire_queue)
+      acquire_queue(rwlock.acquire_queue),
+      type(rwlock.type)
   {}
 
   std::shared_ptr<MCVisibleObject> copy() override;

--- a/include/mcmini/objects/MCRWWLock.h
+++ b/include/mcmini/objects/MCRWWLock.h
@@ -62,13 +62,14 @@ public:
   {}
   inline MCRWWLock(const MCRWWLock &rwwlock)
     : MCVisibleObject(rwwlock.getObjectId()), shadow(rwwlock.shadow),
-      type(rwwlock.type), active_writer1(rwwlock.active_writer1),
+      active_writer1(rwwlock.active_writer1),
       active_writer2(rwwlock.active_writer2),
       active_readers(rwwlock.active_readers),
       reader_queue(rwwlock.reader_queue),
       writer1_queue(rwwlock.writer1_queue),
       writer2_queue(rwwlock.writer2_queue),
-      acquire_queue(rwwlock.acquire_queue)
+      acquire_queue(rwwlock.acquire_queue),
+      type(rwwlock.type)
   {}
 
   std::shared_ptr<MCVisibleObject> copy() override;

--- a/include/mcmini/objects/MCSemaphore.h
+++ b/include/mcmini/objects/MCSemaphore.h
@@ -46,9 +46,10 @@ public:
     : MCVisibleObject(), semShadow(shadow)
   {}
   inline MCSemaphore(const MCSemaphore &sem)
-    : MCVisibleObject(sem.getObjectId()), semShadow(sem.semShadow),
+    : MCVisibleObject(sem.getObjectId()),
       waitingQueue(sem.waitingQueue),
-      spuriousWakeupCount(sem.spuriousWakeupCount)
+      spuriousWakeupCount(sem.spuriousWakeupCount),
+      semShadow(sem.semShadow)
   {}
 
   std::shared_ptr<MCVisibleObject> copy() override;

--- a/include/mcmini/transitions/MCTransitionsShared.h
+++ b/include/mcmini/transitions/MCTransitionsShared.h
@@ -26,9 +26,13 @@ thread_post_visible_operation_hit(const std::type_info &type,
 {
   auto newTypeInfo = MCSharedTransition(tid_self, type);
   auto newShmData  = shmData;
-  memcpy(shmTransitionTypeInfo, &newTypeInfo,
+  // NOTE: This cast could also be done in a more complicated way for C++:
+  //   https://stackoverflow.com/questions/57721104/avoid-wclass-memaccess-on-memcpy-of-a-pod-type-w-copy-disabled
+  memcpy((char *)shmTransitionTypeInfo,
+         (char *)(&newTypeInfo),
          sizeof(MCSharedTransition));
-  memcpy(shmTransitionData, newShmData, sizeof(SharedMemoryData));
+  memcpy((char *)shmTransitionData, (char *)newShmData,
+         sizeof(SharedMemoryData));
 }
 
 void thread_post_visible_operation_hit(const std::type_info &type);

--- a/src/MCSharedTransition.cpp
+++ b/src/MCSharedTransition.cpp
@@ -5,5 +5,7 @@ void
 MCSharedTransitionReplace(MCSharedTransition *shmOld,
                           MCSharedTransition *shmNew)
 {
-  memcpy(shmOld, shmNew, sizeof(MCSharedTransition));
+  // NOTE: This cast could be done in a more complicated C++ way:
+  //       https://stackoverflow.com/questions/66368061/error-clearing-an-object-of-non-trivial-type-with-memset
+  memcpy((void *)shmOld, (void *)shmNew, sizeof(MCSharedTransition));
 }

--- a/src/transitions/MCTransitionsShared.cpp
+++ b/src/transitions/MCTransitionsShared.cpp
@@ -39,6 +39,8 @@ void
 thread_post_visible_operation_hit(const std::type_info &type)
 {
   auto newTypeInfo = MCSharedTransition(tid_self, type);
-  memcpy(shmTransitionTypeInfo, &newTypeInfo,
+  // NOTE:  This cast could be done in a more complicated C++ way:
+  //        https://stackoverflow.com/questions/66368061/error-clearing-an-object-of-non-trivial-type-with-memset
+  memcpy((void *)shmTransitionTypeInfo, (void *)(&newTypeInfo),
          sizeof(MCSharedTransition));
 }


### PR DESCRIPTION
When using `-Wall` (invoked by `configure --enable-debug`), the warnings `-Wreorder` and `-Wclass-memaccess` appear repeatedly for g++.
This PR fixes this.

**NOTE:**: fixed both of these warnings by simple casts.  I also include StackOverflow URLs showing how to fix these warnings in a more complicated way using special C++ tricks, but I prefer the casts, since that keeps it simple.