### PR TITLE
Minor bug in main: Requires 4 args, not 5

### DIFF
--- a/test/deadlock_program/reader_writer/reader_writer_rwlock_deadlock.c
+++ b/test/deadlock_program/reader_writer/reader_writer_rwlock_deadlock.c
@@ -32,7 +32,7 @@ void *writer(void *unused) {
 }
 
 int main(int argc, char* argv[]) {
-    if(argc != 5){
+    if(argc != 4){
         printf("Usage: %s NUM_READERS NUM_WRITERS DEBUG\n", argv[0]);
         return 1;
     }


### PR DESCRIPTION
Trivial bug to fix in rwlock deadlock test