### PR TITLE
cond_signal/bcast: warn if no waiters; lost wakeup?

### DIFF
--- a/include/mcmini/transitions/cond/MCCondTransition.h
+++ b/include/mcmini/transitions/cond/MCCondTransition.h
@@ -8,10 +8,12 @@ struct MCCondTransition : public MCTransition {
 public:
 
   std::shared_ptr<MCConditionVariable> conditionVariable;
+  bool hadWaiters;
   MCCondTransition(
     std::shared_ptr<MCThread> running,
     std::shared_ptr<MCConditionVariable> conditionVariable)
-    : MCTransition(running), conditionVariable(conditionVariable)
+    : MCTransition(running), conditionVariable(conditionVariable),
+      hadWaiters(false)
   {}
 };
 

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -75,6 +75,10 @@ MCCondBroadcast::dependentWith(const MCTransition *other) const
 void
 MCCondBroadcast::print() const
 {
-  printf("thread %lu: pthread_cond_broadcast(cond:%u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
+  const char * isLostWakeup = " [No thread waiting on cond; lost wakeup?]";
+  if (hadWaiters) { isLostWakeup = ""; }
+
+  printf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,
+         countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+         isLostWakeup);
 }

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -76,6 +76,10 @@ MCCondSignal::dependentWith(const MCTransition *other) const
 void
 MCCondSignal::print() const
 {
-  printf("thread %lu: pthread_cond_signal(cond:%u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
+  const char * isLostWakeup = " [No thread waiting on cond; lost wakeup?]";
+  if (hadWaiters) { isLostWakeup = ""; }
+
+  printf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,
+         countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+         isLostWakeup);
 }


### PR DESCRIPTION
In the printed thread trace, if there were no waiters at the time of a `pthread_cond_signal` or `pthread_cond_broadcast`, then the printout of the trace add a warning on the line of that transition: 
> `[No thread waiting on cond; lost wakeup?]`

If you want tot est this, you could try ` test/deadlock_program/simple_cond_deadlock.c`, or many of the bugs that we have for cond vars.