### PR TITLE
mcmini-gdb: fix "mcmini back"

### DIFF
--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -253,12 +253,10 @@ class backCmd(gdb.Command):
       print("GDB is in scheduler, not target process:" +
             "  Can't go to previous transition\n")
       return
-    iterationsForward = transitionId - 1
-    gdb.execute("mcmini finishTrace quiet")
     gdb.execute("set rerunCurrentTraceForDebugger = 1")
-    gdb.execute("mcmini nextTrace quiet")
+    iterationsForward = transitionId - 1
+    transitionId = 0
     gdb.execute("mcmini forward " + str(iterationsForward) + " quiet")
-    gdb.execute("set rerunCurrentTraceForDebugger = 0")
     print("DEBUGGING: " + "mcmini forward " + str(iterationsForward) + " quiet")
     print_user_frames_in_stack()
     print_mcmini_stats()


### PR DESCRIPTION
Previously, the 'mcmini back' command in GDB mode was never really working.
This commit attempts to fix it.

@maxwellpirtle ,
There is a bug in mcmini_private.cpp, when I do `mc_prepare_to_model_check_new_program()`.  I'm sure it's easy for you to fix this bug, or tell me how to do it.

I'm simply trying to re-initialize McMini to begin its search again at `traceId==0`.  But as you can see from my suggested test, below, when I call `mcmini back`, instead of reducing the number of transitions for this trace from 9 to 8, instead, it grows the number of transitions.  So, clearly I did not re-initialize McMini properly to again start at `traceId==0`.  (For motivation, I'm trying to add  support for `mcmini back` when interactively debugging a traceSeq, such as:
> ./mcmini-gdb -f -q -p 0 -p '0, 0, 0, 1, 1, 2'  ./a.out

To test it, use your favorite target multithreaded application, `a.out`, and do:
> ./mcmini-gdb -q  ../a.out
mcmini forward 9
mcmini printTransitions
mcmini back
mcmini printTransitions