### PR TITLE
Fix launch recognizing 'mcmini' as target

### DIFF
--- a/src/launch.c
+++ b/src/launch.c
@@ -40,7 +40,7 @@ main(int argc, char *argv[])
         strcmp(cur_arg[0], "-m") == 0) {
       setenv(ENV_MAX_DEPTH_PER_THREAD, cur_arg[1], 1);
       char *endptr;
-      if (strtol(cur_arg[1], &endptr, 10) == 0 || endptr[0] != '\0') {
+      if (strtol(cur_arg[1], &endptr, 10) == 0 && endptr[0] != '\0') {
         fprintf(stderr, "%s: illegal value\n", "--max-depth-per-thread");
         exit(1);
       }
@@ -54,7 +54,7 @@ main(int argc, char *argv[])
              strcmp(cur_arg[0], "-d") == 0) {
       setenv(ENV_DEBUG_AT_TRACE_ID, cur_arg[1], 1);
       char *endptr;
-      if (strtol(cur_arg[1], &endptr, 10) == 0 || endptr[0] != '\0') {
+      if (strtol(cur_arg[1], &endptr, 10) == 0 && endptr[0] != '\0') {
         fprintf(stderr, "%s: illegal value\n", "--debug-at-traceId");
         exit(1);
       }
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
              strcmp(cur_arg[0], "-p") == 0) {
       setenv(ENV_PRINT_AT_TRACE_ID, cur_arg[1], 1);
       char *endptr;
-      if (strtol(cur_arg[1], &endptr, 10) == 0 || endptr[0] != '\0') {
+      if (strtol(cur_arg[1], &endptr, 10) == 0 && endptr[0] != '\0') {
         fprintf(stderr, "%s: illegal value\n", "--print-at-traceId");
         exit(1);
       }

--- a/src/launch.c
+++ b/src/launch.c
@@ -137,7 +137,7 @@ main(int argc, char *argv[])
              strlen(cur_arg[0]) - strlen("mcmini") - 1 :
              strlen(cur_arg[0]);
   // idx points to 'X' when cur_arg[0] == "...Xmcmini"
-  if (strcmp(cur_arg[0], "mcmini") == 0 || cur_arg[0][idx] == '/') {
+  if (strcmp(cur_arg[0], "mcmini") == 0 ||  strcmp(cur_arg[0] + idx, "/mcmini") == 0) {
     fprintf(stderr,
             "\n*** McMini being called on 'mcmini'.  This doesn't work.\n");
     exit(1);


### PR DESCRIPTION
Two trivial bugs to fix:
1. First commit: `src/launch.c` has error in which target is thought to be 'mcmini' if it has the same number of letters.
2. Second commit: `src/launch.c` has an error in the use of `strtol()`.

----
**First commit**

> mcmini choose

returns:
> *** McMini being called on 'mcmini'.  This doesn't work. 

because "choose" and "mcmini" have the same number of letters.
This fixes that bug.

----
**Second commit**

An obvious fix in usage of `strtol()`