### PR TITLE
mcprintf_redirect: capture output in Python

### DIFF
--- a/configure
+++ b/configure
@@ -5279,8 +5279,8 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if python3 is available" >&5
 printf %s "checking if python3 is available... " >&6; }
 # If Python returns True, that is converted to '1', which is Failure for shell:
-PYTHON=`which python`
-PYTHON3=`which python3`
+PYTHON=`which python 2> /dev/null`
+PYTHON3=`which python3 2> /dev/null`
 if [ "$PYTHON" != "" ] && \
     $PYTHON -c 'import sys; sys.exit(sys.version_info.major < 3)'; then
   has_python=yes
@@ -5360,9 +5360,13 @@ PYTHON_VERSION_MINOR=`$PYTHON -c 'import sys; print("%d" % (sys.version_info.min
 
 # If Python returns True, True is converted to '1', which is Failure for shell:
 # FIXME: We should test if gdb.Frame.level is present, for GDB's need to patch.
+#        This came into GDB somewhere from GDB-10 to GDB-12.
+#        And capture_output flag came into Python3 in python 3.7.
+# CentOS 8 still uses outdated Python and GDB.
 if $PYTHON -c 'import sys; sys.exit('$GDB_VERSION' >= 12 and '$PYTHON_VERSION_MINOR' >= 7)'; then
   echo '*** Python or GDB Python API is older: patching Python code'
-  patch -p1 < mcmini-oldsys.patch
+  echo '*** There may be some smaller missing features for mcminig-gdb.'
+  # patch -p1 < mcmini-oldsys.patch
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if process_vm_readv/process_vm_writev (CMA) available" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -53,8 +53,8 @@ fi
 
 AC_MSG_CHECKING([if python3 is available])
 # If Python returns True, that is converted to '1', which is Failure for shell:
-PYTHON=`which python`
-PYTHON3=`which python3`
+PYTHON=`which python 2> /dev/null`
+PYTHON3=`which python3 2> /dev/null`
 if [[ "$PYTHON" != "" ]] && \
     $PYTHON -c 'import sys; sys.exit(sys.version_info.major < 3)'; then
   has_python=yes

--- a/gdbinit
+++ b/gdbinit
@@ -53,5 +53,8 @@ set pagination on
 
 # Print Python-based GDB commands:
 help user-defined
-echo \n\ \ *** Type 'mcmini help' for usage. ***\n
-echo     \ \ (Do 'set print address off' for less verbose output.)\n\n
+printf "\n****************************************************************************\n\
+*   *** Type 'mcmini help' for usage. ***                                  *\n\
+*   (Do 'set print address off' for less verbose output.)                  *\n\
+* CONSIDER USING:  ctrl-Xa ('ctrl-X' and 'a'), ctrl-Xo, 'winheight src -5' *\n\
+****************************************************************************\n\n"

--- a/gdbinit
+++ b/gdbinit
@@ -48,6 +48,9 @@ continue
 tbreak main
 continue
 
+# The automated script is done.  It's now safe to turn pagination on.
+set pagination on
+
 # Print Python-based GDB commands:
 help user-defined
 echo \n\ \ *** Type 'mcmini help' for usage. ***\n

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -302,7 +302,7 @@ dup_stdout = -1 # uninitialized
 output = "REDIRECT UNINTIALIZED"
 user_inferior = -1
 
-def redirect_prolog():
+def redirect_prolog(inferior=1):
   # NOTE: This doesn't work for TUI; they output to curses, not stdout. :-(
   # FIXME: But we can do tui-disable; update; tui-enable to get around it
   #        We need to capture McMini output and re-print it in tui-enabled in that case.
@@ -332,13 +332,18 @@ def redirect_prolog():
   #   then GDB freezes after doing 'mcmini printTransitions' twice.
   gdb.execute("inferior 1")  # inferior 1 is scheduler process
   gdb.execute("call mcprintf_redirect()")
-  gdb.execute("inferior " + str(user_inferior))
+  cur_stdout = os.open('/dev/null', os.O_WRONLY)
+  gdb.execute("inferior " + str(inferior))  # inferior 1 is scheduler process
+  # Should this be an optional argument? if outside of prolog it will be printed
+  os.dup2(dup_stdout, 1)
   # return context
-  return (dup_stdout, user_inferior, cur_pagination, cur_frame_info)
+  return (dup_stdout, user_inferior, inferior, cur_pagination, cur_frame_info)
 
 def redirect_epilog(context, print_hack = False):
-  (dup_stdout, user_inferior, cur_pagination, cur_frame_info) = context
-  gdb.execute("inferior 1")  # inferior 1 is scheduler process
+  (dup_stdout, user_inferior, inferior, cur_pagination, cur_frame_info) =context
+  os.close(1)
+  cur_stdout = os.open('/dev/null', os.O_WRONLY)
+  gdb.execute("inferior " + str(inferior))  # inferior 1 is scheduler process
   gdb.execute("call mcprintf_stop_redirect()")
   output = gdb.parse_and_eval("mcprintf_redirect_output").string()
   if user_inferior not in [inf.num for inf in gdb.inferiors()]:
@@ -435,14 +440,10 @@ class printTransitionsCmd(gdb.Command):
     if gdb.newest_frame().name() in ["__GI__exit", "_exit"]:
       has_exited = True
     if not has_exited:
-      context = redirect_prolog()
-      user_inferior = gdb.selected_inferior().num
-      gdb.execute("inferior 1")  # inferior 1 is scheduler process
+      context = redirect_prolog(inferior=1)
       gdb.execute("call programState->printTransitionStack()")
+      assert gdb.selected_inferior().num == 1
       gdb.execute("call programState->printNextTransitions()")
-      ## gdb.execute("set scheduler-locking off")
-      gdb.execute("inferior " + str(user_inferior))
-      select_user_frame()
       redirect_epilog(context, print_hack=True)
     else:
       print("Process has exited")
@@ -455,11 +456,8 @@ class printPendingTransitionsCmd(gdb.Command):
         "mcmini printPendingTransitions", gdb.COMMAND_USER
     )
   def invoke(self, args, from_tty):
-    context = redirect_prolog()
-    user_inferior = gdb.selected_inferior().num
-    gdb.execute("inferior 1")  # inferior 1 is scheduler process
+    context = redirect_prolog(inferior=1)
     gdb.execute("call programState->printNextTransitions()")
-    gdb.execute("inferior " + str(user_inferior))
     redirect_epilog(context)
 printPendingTransitionsCmd()
 
@@ -537,15 +535,16 @@ class forwardCmd(gdb.Command):
       pass
     continue_until("mc_shared_sem_wait_for_scheduler_done")
     # FIXME: There can be many aliases for "_exit".  We should use address.
-    if gdb.newest_frame().name() != "__GI__exit":
-      finish()
-    else:
+    if gdb.selected_inferior().pid == 0 or \
+       gdb.newest_frame().name() == "__GI__exit":
       # FIXME:  Stop scheduler from exiting, so that 'mcmini back' works.
-      gdb.execute("inferior " + str(gdb.inferiors()[-1].num))
-      gdb.execute("set unwindonsignal on")
+      if gdb.selected_inferior().pid != 0:
+        gdb.execute("inferior " + str(gdb.inferiors()[-1].num))
+        gdb.execute("set unwindonsignal on")
       print("\n*** McMini scheduler has exited." +
             "  Suggestion: 'mcmini printTransitions'")
       return
+    finish()
     transitionId += 1
     if "quiet" not in args:
       select_user_frame()

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -85,8 +85,9 @@ if "-p0" not in mcmini_args and "'-p' '0'" not in mcmini_args:
   mcmini_output = mcmini_output.stdout.decode('utf-8').split('\n')
   pending_indexes = [idx for idx, line in enumerate(mcmini_output)
                          if "THREAD PENDING OPERATIONS" in line]
+  # '-v' will insert many "THREAD PENDING" msg's; Use last one for '-f'
   if pending_indexes:
-     trace_seq = mcmini_output[pending_indexes[0]-2]
+     trace_seq = mcmini_output[pending_indexes[-1]-2]
   else:
     trace_indexes = [idx for idx, line in enumerate(mcmini_output)
                          if line.startswith("TraceId ")]

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -413,7 +413,7 @@ mcminiHelpString=(
 * For details of 'mcmini' commands, type 'help user-defined' and the online    *
 * McMini manual.                                                               *
 *                                                                              *
-* CONSIDER USING ctrl-Xa ('ctrl-X' and 'a') TO TOGGLE SOURCE DISPLAY ON OR OFF.*
+* CONSIDER USING:  ctrl-Xa ('ctrl-X' and 'a'), ctrl-Xo, 'winheight src -5'     *
 ********************************************************************************
 """
 )
@@ -521,7 +521,8 @@ class forwardCmd(gdb.Command):
     if gdb.selected_inferior().num == 1 and gdb.inferiors()[-1].num > 0:
       gdb.execute("inferior " + str(gdb.inferiors()[-1].num))
     if gdb.selected_inferior().num == 1:
-      print("No target available.  Did it exit?")
+      print("\n*** McMini target process has exited." +
+            "  Suggestion: 'mcmini printTransitions'")
       return
     if iterations == 0:
       print_current_frame_verbose()

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -301,6 +301,8 @@ def finish():
   bkpt = gdb.FinishBreakpoint(internal=True)
   bkpt.silent = True
   gdb.execute("continue")
+  if not gdb.selected_thread():
+    gdb.execute("inferior 1")  # User thread must have exited.
 
 # NOTE: gdb.Breakpoint.stop() can be defined to do anything arbitrary when
 #                       reaching the breakpoint, such as print a message.

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -279,10 +279,16 @@ def continue_until(function, thread_id=None):
   bkpt_exit.silent = True
   if thread_id:
     bkpt.thread = thread_id
-  while bkpt.hit_count == 0:
+  exit_was_hit = False
+  while bkpt.hit_count == 0 and not exit_was_hit:
     if bkpt_exit.hit_count > 0:
-      return
-    mcmini_execute("continue")
+      exit_was_hit = True
+      gdb.execute("inferior 1")
+      finish()
+      gdb.execute("inferior 1")
+      finish()
+    else:
+      mcmini_execute("continue")
   bkpt.delete()
   bkpt_exit.delete()
 

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -62,7 +62,20 @@ import os, subprocess, time
 assert "MCMINI_ARGS" in os.environ
 mcmini_args = os.getenv("MCMINI_ARGS")
 del os.environ["MCMINI_ARGS"]
-if "-p0" not in mcmini_args and "'-p' '0'" not in mcmini_args:
+
+def insert_extra(args, extra):
+  args = args.split()
+  last_flag_idx = max([ idx for (idx, word) in enumerate(args)
+                            if word.startswith('-') or word.startswith("'-") ],
+                      default = 0)
+  last_word = args[last_flag_idx].replace("'", "")
+  if last_word in [ "--max-depth-per-thread", "--print-at-trace"] or \
+     len(last_word) == 2 and last_word[1] in ['m', 'p']:
+    last_flag_idx += 1
+  args = args[:last_flag_idx] + extra.split() + args[last_flag_idx:]
+  return ' '.join(args)
+
+if "-p0" not in mcmini_args.split() and "'-p' '0'" not in mcmini_args:
   # If "-p0" not in the mcmini arguments, then get the trace sequence first.
   # We will then add "-p 0 -p <traceSeq>" to the command line before giving
   #   control to gdb.
@@ -104,9 +117,40 @@ if "-p0" not in mcmini_args and "'-p' '0'" not in mcmini_args:
         print("******** mcmini-gdb: Internal error:"
               " can't compute trace sequence")
       gdb.execute("quit")
-  extra_args = " -p 0 -p'" + trace_seq + "' "
-  mcmini_args = (mcmini_args.rsplit(maxsplit=1)[0] + extra_args +
-                 mcmini_args.rsplit(maxsplit=1)[1])
+  extra_args = " -p0 -p'" + trace_seq + "' "
+
+  mcmini_args = mcmini_args.split()
+  # Strip "'" if it surrounds an arg with no spaces:
+  for i in range(len(mcmini_args)):
+    if len(mcmini_args[i].strip("'"))+2 == len(mcmini_args[i]):
+      mcmini_args[i] = mcmini_args[i].strip("'")
+  # Remove any old prefixes: '-p 0,0, ...' (or variations)
+  for i in range(len(mcmini_args)):
+    if "-p" in mcmini_args[i] and "'" in mcmini_args[i] or \
+       i > 0 and mcmini_args[i-1] == "-p" and "'" in mcmini_args[i]:
+      j =  i if "-p" in mcmini_args[i] else i-1
+      mcmini_args[j] = ""
+      for k in range(j+1, len(mcmini_args)):
+        tmp = mcmini_args[k]
+        mcmini_args[k] = ""
+        if tmp.endswith("'"): # If this is the matching "'":
+          break
+  # Now, rejoin the edited words in mcmini_args
+  def delete_one(elt, args):
+    if len([1 for arg in args if arg == elt]) > 1:
+      args[args.index(elt)] = ""
+  # mcmini-gdb must not use '-f' cmd; Else upon last transition, scheduler exits
+  mcmini_args = [ arg for arg in mcmini_args if "-f" != arg ]
+  delete_one("-q", mcmini_args)
+  delete_one("-v", mcmini_args)
+  tmp = [arg for arg in mcmini_args
+         if arg.startswith("-p") and len(arg) == 3 and arg != "-p0"]
+  if tmp:
+    mcmini_args[ mcmini_args.index(tmp[0]) ] = ""
+  mcmini_args = ' '.join([arg for arg in mcmini_args if arg != ""])
+  mcmini_args = mcmini_args.replace("-p0 ", "").replace("-p 0 ", "")
+
+  mcmini_args = insert_extra(mcmini_args, extra_args)
   print("** Running: " + exec_file + "-gdb " + mcmini_args)
   print("** Note:  In order to replay this trace,\n" +
         "          it is faster to directly run the above command line.\n")
@@ -179,11 +223,15 @@ def select_user_frame():
   frame.select()
   if is_tui_active():
     # We've selected the frame, but the GDB 'frame' cmd will now tell the TUI.
-    # For forcing TUI redisplay, alternatives to the GDB 'frame' cmd might be
-    # "tui disable; tui enable", or GDB "update" cmd, or GDB "down; up".
+    # For forcing TUI redisplay.
     # FIXME:  Don't do this if the TUI already knows about our frame.
     #         For example, 'mcmini where/print' doesn't need to change it.
+    #         GDB commands: up; down;  fix the display, but print to output
+    #                       and leave current line at top.
     gdb.execute("frame " + str( gdb.selected_frame().level() ))
+    ## GDB BUG: 'list <LINE>' should help TUI to center display; but this fails.
+    # if gdb.execute("frame " + str( gdb.selected_frame().level() )):
+    #   gdb.execute("list " + str( gdb.selected_frame().find_sal().line ))
     gdb.execute("refresh")
 
 # ===========================================================
@@ -248,6 +296,84 @@ def finish():
 #                       reaching the breakpoint, such as print a message.
 
 # ===========================================================
+# Redirect output:  gdb-msg -> /dev/null; McMini -> mcprintf_redirect()
+
+dup_stdout = -1 # uninitialized
+output = "REDIRECT UNINTIALIZED"
+user_inferior = -1
+
+def redirect_prolog():
+  # NOTE: This doesn't work for TUI; they output to curses, not stdout. :-(
+  # FIXME: But we can do tui-disable; update; tui-enable to get around it
+  #        We need to capture McMini output and re-print it in tui-enabled in that case.
+  # TODO:  For TUI, prolog should have cmd and args, disable, execute enable, print '(gdb) cmd line; output', enable
+  # TODO:  Could maybe also print last_output before printing output if desired.
+  # Replace original stdout/stderr by /dev/null
+  # Turn pagination off; GDB junk should not go to paginated stream.
+  cur_pagination = gdb.parameter("pagination")
+  gdb.set_parameter("pagination", "off")
+  # GDB 'inferior XXX' normally tries to print filename, and errors and
+  #   and sends to stderr Stop trying to print filename.  This prevents that.
+  cur_frame_info = gdb.execute("show print frame-info", to_string=True)
+  cur_frame_info = cur_frame_info.split('"')[1]
+  gdb.execute("set print frame-info location")
+  ### if not is_tui_active() and not tui_was_initiated:
+  ###   gdb.execute("tui enable")
+  ###   gdb.execute("tui disable")
+  dup_stdout = os.dup(1)
+  os.close(1)
+  cur_stdout = os.open('/dev/null', os.O_WRONLY)
+  assert cur_stdout == 1
+  # GDB messages will now go to /dev/null
+  user_inferior = gdb.selected_inferior().num
+  # FIXME:  We need 'inferior 1' to call 'mcprintf_redirect()'
+  #   But 'inferior 1' cmd sends junk msg to stderr.
+  #   If we temporarily set stderr to /dev/null, as with stdout,
+  #   then GDB freezes after doing 'mcmini printTransitions' twice.
+  gdb.execute("inferior 1")  # inferior 1 is scheduler process
+  gdb.execute("call mcprintf_redirect()")
+  gdb.execute("inferior " + str(user_inferior))
+  # return context
+  return (dup_stdout, user_inferior, cur_pagination, cur_frame_info)
+
+def redirect_epilog(context, print_hack = False):
+  (dup_stdout, user_inferior, cur_pagination, cur_frame_info) = context
+  gdb.execute("inferior 1")  # inferior 1 is scheduler process
+  gdb.execute("call mcprintf_stop_redirect()")
+  output = gdb.parse_and_eval("mcprintf_redirect_output").string()
+  if user_inferior not in [inf.num for inf in gdb.inferiors()]:
+    user_inferior = [inf.num for inf in gdb.inferiors()][-1]
+    if user_inferior == 1: print("WARNING:  program exited??")
+  # Under TUI, this seems to go to curses (or stderr?), not stdout:
+  gdb.execute("set print frame-info " + cur_frame_info)
+  gdb.execute("inferior " + str(user_inferior))
+  select_user_frame()
+  if is_tui_active():
+    gdb.execute("frame " + str(gdb.selected_frame().level()))
+  # Return to original stdout/stderr
+  # FIXME: When is_tui_active(), we can't replace stdout
+  os.close(1)
+  os.dup2(dup_stdout, 1)
+  os.close(dup_stdout)
+  # It's now safe to print
+  gdb.flush()
+  gdb.set_parameter("pagination", "on" if cur_pagination else "off")
+  # We need this hack because GDB TUI doesn't erase part of first line.
+  if is_tui_active() and print_hack:
+    print(" === ")
+    output = "*** " + output
+  print(output)
+  ## gdb.execute('printf "' + output.replace("\n", "\\n") + '"')
+  ## gdb.write(output)
+  gdb.flush()
+  if is_tui_active():
+    # BUG: Doing: mcmini forward 6; mcmini printTransitionss; ^Xa; up-arrow
+    #      then sets TUI src window to "No source available".
+    #      If we type this below manually, it refreshes, but not under Python.
+    gdb.execute("frame " + str( gdb.selected_frame().level() ))
+    gdb.execute("refresh")
+
+# ===========================================================
 # Set up McMini commands
 
 class mcminiPrefixCmd(gdb.Command):
@@ -307,15 +433,19 @@ class printTransitionsCmd(gdb.Command):
   def invoke(self, args, from_tty):
     has_exited = False
     if gdb.newest_frame().name() in ["__GI__exit", "_exit"]:
-      gdb.execute("continue")
       has_exited = True
-    current_inferior = gdb.selected_inferior().num
-    gdb.execute("inferior 1")  # inferior 1 is scheduler process
-    gdb.execute("call programState->printTransitionStack()")
-    gdb.execute("call programState->printNextTransitions()")
     if not has_exited:
-      gdb.execute("inferior " + str(current_inferior))
+      context = redirect_prolog()
+      user_inferior = gdb.selected_inferior().num
+      gdb.execute("inferior 1")  # inferior 1 is scheduler process
+      gdb.execute("call programState->printTransitionStack()")
+      gdb.execute("call programState->printNextTransitions()")
+      ## gdb.execute("set scheduler-locking off")
+      gdb.execute("inferior " + str(user_inferior))
       select_user_frame()
+      redirect_epilog(context, print_hack=True)
+    else:
+      print("Process has exited")
 printTransitionsCmd()
 
 class printPendingTransitionsCmd(gdb.Command):
@@ -325,11 +455,12 @@ class printPendingTransitionsCmd(gdb.Command):
         "mcmini printPendingTransitions", gdb.COMMAND_USER
     )
   def invoke(self, args, from_tty):
-    current_inferior = gdb.selected_inferior().num
+    context = redirect_prolog()
+    user_inferior = gdb.selected_inferior().num
     gdb.execute("inferior 1")  # inferior 1 is scheduler process
     gdb.execute("call programState->printNextTransitions()")
-    gdb.execute("inferior " + str(current_inferior))
-    select_user_frame()
+    gdb.execute("inferior " + str(user_inferior))
+    redirect_epilog(context)
 printPendingTransitionsCmd()
 
 import re
@@ -448,6 +579,7 @@ class backCmd(gdb.Command):
       print("ERROR: Trying to go back past beginning:" +
             " transitionId=%d; count=%d" % (transitionId, count))
       return
+    context = redirect_prolog()
     transitionId = 0
     inferior_num = gdb.selected_inferior().num
     if gdb.selected_inferior().num != 1: gdb.execute("inferior 1")
@@ -466,6 +598,7 @@ class backCmd(gdb.Command):
     continue_until("mc_shared_sem_wait_for_scheduler_done")
     # We're now at the beginning of the trace (user: "mcmini_main") constructor.
     continue_until("main")
+    redirect_epilog(context)
     # We're now at the beginning of the trace (user: "main").
     # After this, stap at mc_shared_sem_wait_for_scheduler_done for transition.
     gdb.execute("mcmini forward " + str(iterationsForward))
@@ -609,13 +742,13 @@ class developerModeCmd(gdb.Command):
     print("Breakpoint added at next visible operation in scheduler process.")
     gdb.execute("break mc_run_thread_to_next_visible_operation(unsigned long)")
     ### These commented commands will go away, when it's clear it's not needed.
-    # current_inferior = gdb.selected_inferior().num
+    # user_inferior = gdb.selected_inferior().num
     # gdb.execute("inferior 1") # Set inferior to scheduler
     # scheduler_call_frame_fnc = "mc_shared_sem_wait_for_thread"
     # gdb.execute("break " + scheduler_call_frame_fnc)
     # This next command forces a GDB-internal bug in gdb-12.0
     # gdb.FinishBreakpoint().__init__(find_call_frame_fnc(scheduler_call_frame_fnc))
-    # gdb.execute("inferior " + str(current_inferior))
+    # gdb.execute("inferior " + str(user_inferior))
     gdb.execute("inferior 1")
     gdb.execute("set print address on")
     gdb.execute("set detach-on-fork on")

--- a/include/mcmini/MCStack.h
+++ b/include/mcmini/MCStack.h
@@ -26,10 +26,22 @@ typedef MCTransition *(*MCSharedMemoryHandler)(
 
 
 /**
+ * @brief Set 'lastEnedOfTraceId = traceId'.
+ * getNextTraceSeqEntry(...) will now always return '-1'.
+ */
+void setEndOfTraceSeq();
+
+/**
  * @brief When '-p<traceSeq>' is invoked, then the traceSeq needs to be
  * reset when a trace is completed.
  */
 void resetTraceSeqArray();
+
+/**
+ * @brief Return number of terms in traceSeq[] until '-1'.
+ * This is used to decide if 'depth' is beyod the traceSeq in mcini_private.cpp.
+ */
+unsigned int traceSeqLength();
 
 /* This is returned by getDeepestDPORBranchPoint() if this is the
  * first (origina) branch.  mc_do_model_checking() uses this to detect

--- a/include/mcmini/MCStack.h
+++ b/include/mcmini/MCStack.h
@@ -537,9 +537,9 @@ public:
   bool hasADataRaceWithNewTransition(const MCTransition &) const;
 
   inline bool
-  isTargetTraceIdForStackContents(trid_t trid) const
+  isTargetTraceIdForPrintBacktrace(trid_t trid) const
   {
-    return this->configuration.stackContentDumpTraceNumber == trid;
+    return this->configuration.printBacktraceAtTraceNumber == trid;
   }
 
   // Restarting

--- a/include/mcmini/MCStack.h
+++ b/include/mcmini/MCStack.h
@@ -541,6 +541,13 @@ public:
   {
     return this->configuration.printBacktraceAtTraceNumber == trid;
   }
+  // Silly C++ style; Don't let other code know the configuration,
+  // and then punch holdes to disclose private invormation.
+  inline int
+  traceIdForPrintBacktrace() const
+  {
+    return this->configuration.printBacktraceAtTraceNumber;
+  }
 
   // Restarting
   // TODO: This is extremely unclear. I'm going to work on this...

--- a/include/mcmini/MCStackConfiguration.h
+++ b/include/mcmini/MCStackConfiguration.h
@@ -8,9 +8,8 @@
  * may execute as many transitions as they would like (i.e. are
  * not limited to an execution depth)
  */
-#define MC_STATE_CONFIG_THREAD_NO_LIMIT         (UINT64_MAX)
-#define MC_STATE_CONFIG_NO_GDB_TRACE            (UINT64_MAX)
-#define MC_STAT_CONFIG_NO_TRANSITION_STACK_DUMP (UINT64_MAX)
+#define MC_STATE_CONFIG_THREAD_NO_LIMIT (UINT64_MAX)
+#define MC_STATE_CONFIG_PRINT_AT_TRACE  (UINT64_MAX)
 
 /**
  * A struct which describes the configurable parameters
@@ -28,7 +27,7 @@ struct MCStackConfiguration final {
    * The trace id to stop the model checker at
    * to print the contents of the transition stack.
    */
-  const trid_t stackContentDumpTraceNumber;
+  const trid_t printBacktraceAtTraceNumber;
 
   /**
    * Whether or not this model checking session is
@@ -44,11 +43,11 @@ struct MCStackConfiguration final {
   const bool expectForwardProgressOfThreads;
 
   MCStackConfiguration(uint64_t maxThreadExecutionDepth,
-                       trid_t stackContentDumpTraceNumber,
+                       trid_t printBacktraceAtTraceNumber,
                        bool firstDeadlock,
                        bool expectForwardProgressOfThreads)
     : maxThreadExecutionDepth(maxThreadExecutionDepth),
-      stackContentDumpTraceNumber(stackContentDumpTraceNumber),
+      printBacktraceAtTraceNumber(printBacktraceAtTraceNumber),
       expectForwardProgressOfThreads(expectForwardProgressOfThreads)
   {}
 };

--- a/include/mcmini/MCStackConfiguration.h
+++ b/include/mcmini/MCStackConfiguration.h
@@ -26,13 +26,7 @@ struct MCStackConfiguration final {
 
   /**
    * The trace id to stop the model checker at
-   * to allow GDB to run through a trace
-   */
-  const trid_t gdbDebugTraceNumber;
-
-  /**
-   * The trace id to stop the model checker at
-   * to print the contents of the transition stack
+   * to print the contents of the transition stack.
    */
   const trid_t stackContentDumpTraceNumber;
 
@@ -50,12 +44,10 @@ struct MCStackConfiguration final {
   const bool expectForwardProgressOfThreads;
 
   MCStackConfiguration(uint64_t maxThreadExecutionDepth,
-                       trid_t gdbDebugTraceNumber,
                        trid_t stackContentDumpTraceNumber,
                        bool firstDeadlock,
                        bool expectForwardProgressOfThreads)
     : maxThreadExecutionDepth(maxThreadExecutionDepth),
-      gdbDebugTraceNumber(gdbDebugTraceNumber),
       stackContentDumpTraceNumber(stackContentDumpTraceNumber),
       expectForwardProgressOfThreads(expectForwardProgressOfThreads)
   {}

--- a/include/mcmini/transitions/wrappers/MCSharedLibraryWrappers.h
+++ b/include/mcmini/transitions/wrappers/MCSharedLibraryWrappers.h
@@ -15,6 +15,7 @@ extern typeof(&pthread_mutex_unlock) pthread_mutex_unlock_ptr;
 extern typeof(&sem_wait) sem_wait_ptr;
 extern typeof(&sem_post) sem_post_ptr;
 extern typeof(&sem_init) sem_init_ptr;
+extern typeof(&sem_destroy) sem_destroy_ptr;
 extern __attribute__((__noreturn__)) typeof(&exit) exit_ptr;
 extern __attribute__((__noreturn__)) typeof(&abort) abort_ptr;
 extern typeof(&pthread_barrier_init) pthread_barrier_init_ptr;
@@ -37,6 +38,7 @@ extern typeof(&sleep) sleep_ptr;
 #define __real_sem_wait               (*sem_wait_ptr)
 #define __real_sem_post               (*sem_post_ptr)
 #define __real_sem_init               (*sem_init_ptr)
+#define __real_sem_destroy            (*sem_destroy_ptr)
 #define __real_exit                   (*exit_ptr)
 #define __real_abort                  (*abort_ptr)
 #define __real_pthread_barrier_init   (*pthread_barrier_init_ptr)

--- a/mcmini-gdb.in
+++ b/mcmini-gdb.in
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 export MCMINI_ROOT=@PWD@
+if test ! -e $MCMINI_ROOT/mcmini; then
+  echo "$MCMINI_ROOT/mcmini not found"
+  echo "Was 'make' run during McMini install?"
+  echo ""
+  exit 1
+fi
 if test "$1" = ""; then
   echo "USAGE:  $0 [OPTIONS] TARGET_FILE"
   $MCMINI_ROOT/mcmini

--- a/src/MCCommon.c
+++ b/src/MCCommon.c
@@ -1,12 +1,56 @@
 #include "mcmini/MCCommon.h"
 
+/* We want to allow GDB to temporarily set mcprintf_redirect to true,
+ * so that mcprintf() does not immediately print to stdout.
+ * A GDB script can then use:
+ * gdb.execute("call mcprintf_redirect()")
+ *   ...
+ * gdb.execute("call mcprintf_stop_redirect()")
+ * output = gdb.parse_and_eval("mcprintf_redirect_output").string()
+ *   and later do:  (gdb) python print(output)
+ *
+ * The GDB variable max-value-size (default: 64 KB) determines
+ * the maximum size of mcprintf_redirect_output[];
+ */
+static char mcprintf_redirect_output[10000];
+#define NORMAL (-1)
+static int mcprintf_idx = NORMAL;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+static void mcprintf_redirect()
+{
+  mcprintf_idx = 0;
+  mcprintf_redirect_output[0] = '\0';
+}
+static void mcprintf_stop_redirect() { mcprintf_idx = NORMAL; }
+#pragma GCC diagnostic pop
+
 int
 mcprintf(const char *format, ...)
 {
   va_list args;
   va_start(args, format);
-  int ret = vprintf(format, args);
-  mcflush();
+  int ret = -1;
+  if (mcprintf_idx == NORMAL) {
+    ret = vprintf(format, args);
+    mcflush();
+  } else {
+    if (mcprintf_idx >= sizeof mcprintf_redirect_output - 200) {
+      snprintf(mcprintf_redirect_output +
+                 sizeof mcprintf_redirect_output - 100 - 200,
+               sizeof mcprintf_redirect_output, "$s",
+               "\n*** McMini: mcprintf_redirect_output full;"
+               " Increase it and GDB max-value-size?\n");
+    } else {
+      ret = vsnprintf(mcprintf_redirect_output + mcprintf_idx,
+                      sizeof mcprintf_redirect_output,
+                      format, args);
+      mcprintf_idx += ret;
+      if (ret >= sizeof mcprintf_redirect_output) { // then truncate:
+        mcprintf_redirect_output[sizeof(mcprintf_redirect_output) - 1] = '\0';
+      }
+    }
+  }
   va_end(args);
   return ret;
 }

--- a/src/MCCommon.c
+++ b/src/MCCommon.c
@@ -36,14 +36,13 @@ mcprintf(const char *format, ...)
     mcflush();
   } else {
     if (mcprintf_idx >= sizeof mcprintf_redirect_output - 200) {
-      snprintf(mcprintf_redirect_output +
-                 sizeof mcprintf_redirect_output - 100 - 200,
-               sizeof mcprintf_redirect_output, "$s",
+      snprintf(mcprintf_redirect_output + sizeof mcprintf_redirect_output - 200,
+               200, "%s",
                "\n*** McMini: mcprintf_redirect_output full;"
                " Increase it and GDB max-value-size?\n");
     } else {
       ret = vsnprintf(mcprintf_redirect_output + mcprintf_idx,
-                      sizeof mcprintf_redirect_output,
+                      sizeof mcprintf_redirect_output - mcprintf_idx,
                       format, args);
       mcprintf_idx += ret;
       if (ret >= sizeof mcprintf_redirect_output) { // then truncate:

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -36,12 +36,13 @@ static void trace_string_to_int_array(char *str, int *traceArray,
       mc_stop_model_checking(EXIT_FAILURE);
     }
 
-    long num = strtol(str, &str, 10);
-    char *str2 = str;
-    for (; *str2 == ' '; str2++);
-    if (num == 0 && *str2 == '\0') {
+    char *endptr;
+    long num = strtol(str, &endptr, 10);
+    if (str == endptr) {
       break; // We've seen all the numbers in the array.
     }
+    str = endptr;
+    for (; *str == ' '; str++);
 
     traceArray[traceArrayIdx++] = num;
     if (traceArrayIdx >= traceArrayLen) {

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -12,12 +12,20 @@ extern "C" {
 
 using namespace std;
 
-static int traceSeq[1000] = {-1};
+int traceSeq[1000] = {-1};
 static int traceSeqIdx = 1;  // traceSeq[0] is for thread 0 'starts'. Skip it.
 static int lastEndOfTraceId = -1;
 
+void setEndOfTraceSeq() {
+  lastEndOfTraceId = traceId;
+}
 void resetTraceSeqArray() {
   traceSeqIdx = 0;  // traceSeq[0] is for thread 0 'starts'. Skip it.
+}
+unsigned int traceSeqLength() {
+  unsigned int i;
+  for (i = 0; traceSeq[i] != -1; i++);
+  return i;
 }
 
 static void trace_string_to_int_array(char *str, int *traceArray,
@@ -89,7 +97,7 @@ static int getNextTraceSeqEntry(int traceSeqIdx) {
            traceSeqLen, (traceSeqLen>=10 ? "" : " "));
       }
       print_at_trace_seq = false;
-      lastEndOfTraceId = traceId;
+      setEndOfTraceSeq();
       return -1; // -1 means end of traceSeq; Continue as mormal.
     } else {
       return traceSeq[traceSeqIdx];

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -1046,32 +1046,32 @@ MCStack::printThreadSchedule() const
 {
   for (int i = 0; i <= this->transitionStackTop; i++) {
     const tid_t tid = this->getTransitionAtIndex(i).getThreadId();
-    printf("%lu, ", tid);
+    mcprintf("%lu, ", tid);
   }
-  printf("\n");
+  mcprintf("\n");
 }
 
 void
 MCStack::printTransitionStack() const
 {
-  printf("THREAD BACKTRACE\n");
+  mcprintf("THREAD BACKTRACE\n");
   for (int i = 0; i <= this->transitionStackTop; i++) {
     this->getTransitionAtIndex(i).print();
   }
   MCStack::printThreadSchedule();
-  printf("END\n");
+  mcprintf("END\n");
   mcflush();
 }
 
 void
 MCStack::printNextTransitions() const
 {
-  printf("THREAD PENDING OPERATIONS\n");
+  mcprintf("THREAD PENDING OPERATIONS\n");
   auto numThreads = this->getNumProgramThreads();
   for (uint64_t i = 0; i < numThreads; i++) {
     this->getNextTransitionForThread(i).print();
   }
-  printf("END\n");
+  mcprintf("END\n");
   mcflush();
 }
 

--- a/src/mc_shared_sem.c
+++ b/src/mc_shared_sem.c
@@ -33,7 +33,7 @@ void
 mc_shared_sem_wait_for_scheduler(mc_shared_sem_ref ref)
 {
   __real_sem_wait(&ref->pthread_sem);
-  // We have this for gdbini_command: mcmini forward
+  // We have this for gdbinit_command: mcmini forward
   mc_shared_sem_wait_for_scheduler_done();
 }
 

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -698,7 +698,6 @@ get_config_for_execution_environment()
   // single process that forks, exec()s w/LD_PRELOAD set, and then
   // remotely controls THAT process. We need to discuss this
   uint64_t maxThreadDepth = MC_STATE_CONFIG_THREAD_NO_LIMIT;
-  trid_t gdbTraceNumber   = MC_STATE_CONFIG_NO_GDB_TRACE;
   trid_t stackContentDumpTraceNumber = MC_STAT_CONFIG_NO_TRANSITION_STACK_DUMP;
   bool firstDeadlock                  = false;
   bool expectForwardProgressOfThreads = false;
@@ -706,10 +705,6 @@ get_config_for_execution_environment()
   // TODO: Sanitize arguments (check errors of strtoul)
   if (getenv(ENV_MAX_DEPTH_PER_THREAD) != NULL) {
     maxThreadDepth = strtoul(getenv(ENV_MAX_DEPTH_PER_THREAD), nullptr, 10);
-  }
-
-  if (getenv(ENV_DEBUG_AT_TRACE_ID) != NULL) {
-    gdbTraceNumber = strtoul(getenv(ENV_DEBUG_AT_TRACE_ID), NULL, 10);
   }
 
   if (getenv(ENV_PRINT_AT_TRACE_ID) != NULL) {
@@ -724,7 +719,7 @@ get_config_for_execution_environment()
     firstDeadlock = true;
   }
 
-  return {maxThreadDepth, gdbTraceNumber, stackContentDumpTraceNumber,
+  return {maxThreadDepth, stackContentDumpTraceNumber,
           firstDeadlock, expectForwardProgressOfThreads};
 }
 

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -610,6 +610,8 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
 
   const bool hasDeadlock = programState->isInDeadlock();
   const bool programHasNoErrors = !hasDeadlock;
+  char *v = getenv(ENV_VERBOSE);
+  bool verbose = v ? v[0] == '1' : false;
 
   if (hasDeadlock) {
     mcprintf("TraceId %lu, *** DEADLOCK DETECTED ***\n", traceId);
@@ -624,9 +626,8 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
     }
   }
 
-  static char *verbose = getenv(ENV_VERBOSE);
-  if (programHasNoErrors && verbose) {
-    if (verbose[0] == '1') {
+  if (programHasNoErrors) {
+    if (verbose) {
       mcprintf("TraceId %3d:  ", traceId);
       programState->printThreadSchedule();
     } else {

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -280,6 +280,12 @@ mc_explore_branch(int curBranchPoint)
   mc_exit_with_trace_if_necessary(traceId);
 
   traceId++;
+  if (false && traceId >= 1 && getenv(ENV_PRINT_AT_TRACE_SEQ) != NULL) {
+    mcprintf("*** Trace sequence ('-p', --print-at-trace') requested.\n"
+             "*** for more than one traceDd: -p<X> -p'<traceSeq>' for X>0\n"
+             "*** McMini cannot yet handle this situation.  Exiting now.\n");
+    mc_exit(EXIT_FAILURE);
+  }
   resetTraceSeqArray();
   if (traceId % 1000 == 0) {
     static time_t last_time_reported = mcmini_start_time;
@@ -559,6 +565,14 @@ void
 mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
 {
   uint64_t depth = programState->getTransitionStackSize();
+  if (traceId >= 1 && getenv(ENV_PRINT_AT_TRACE_SEQ) != NULL) {
+    if (depth < traceSeqLength()) {
+      printResults();
+      mc_stop_model_checking(EXIT_SUCCESS); // Exit McMini
+    } else {
+      setEndOfTraceSeq(); // Stop using traceSeq[].
+    }
+  }
   const MCTransition &initialTransition =
     programState->getNextTransitionForThread(backtrackThread);
   const MCTransition *nextTransition = &initialTransition;

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -64,6 +64,12 @@ static void printResults() {
   mcprintf("Number of traces: %lu\n", traceId);
   mcprintf("Total number of transitions: %lu\n", transitionId);
   mcprintf("Elapsed time: %lu seconds\n", time(NULL) - mcmini_start_time);
+  if ((int)traceId < programState->traceIdForPrintBacktrace() &&
+      getenv(ENV_FIRST_DEADLOCK) == NULL) { // and no --first-deadlock
+    mcprintf("*** NOTE: --print-at-trace (-p) requested up to trace %d,\n"
+            "           but total number of traces was only %d.\n",
+            programState->traceIdForPrintBacktrace(), traceId);
+  }
 }
 
 /*

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -624,6 +624,10 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
     programState->printTransitionStack();
     programState->printNextTransitions();
     addResult("*** DEADLOCK DETECTED ***\n");
+    if (verbose) {
+      mcprintf("TraceId %ld:  ", traceId);
+      programState->printThreadSchedule();
+    }
 
     if (getenv(ENV_FIRST_DEADLOCK) != NULL) {
       traceId++; // Verify "Number of traces" in printResults() is correct.
@@ -634,7 +638,7 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
 
   if (programHasNoErrors) {
     if (verbose) {
-      mcprintf("TraceId %3d:  ", traceId);
+      mcprintf("TraceId %ld:  ", traceId);
       programState->printThreadSchedule();
     } else {
       mcprintf("TraceId: %d, *** NO FAILURE DETECTED ***\n", traceId);

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -277,6 +277,7 @@ mc_explore_branch(int curBranchPoint)
   }
 
   mc_search_dpor_branch_with_thread(backtrackThread);
+  // If '-p <traceId>' set and current traceId matches it, then exit.
   mc_exit_with_trace_if_necessary(traceId);
 
   traceId++;

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -618,6 +618,7 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
     addResult("*** DEADLOCK DETECTED ***\n");
 
     if (getenv(ENV_FIRST_DEADLOCK) != NULL) {
+      traceId++; // Verify "Number of traces" in printResults() is correct.
       printResults();
       mc_exit(EXIT_SUCCESS);
     }

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -679,7 +679,7 @@ mc_report_undefined_behavior(const char *msg)
 void
 mc_exit_with_trace_if_necessary(trid_t trid)
 {
-  if (programState->isTargetTraceIdForStackContents(trid)) {
+  if (programState->isTargetTraceIdForPrintBacktrace(trid)) {
     mcprintf("*** -p or --print-at-trace requested.  Printing trace:\n");
     programState->printTransitionStack();
     programState->printNextTransitions();
@@ -698,7 +698,7 @@ get_config_for_execution_environment()
   // single process that forks, exec()s w/LD_PRELOAD set, and then
   // remotely controls THAT process. We need to discuss this
   uint64_t maxThreadDepth = MC_STATE_CONFIG_THREAD_NO_LIMIT;
-  trid_t stackContentDumpTraceNumber = MC_STAT_CONFIG_NO_TRANSITION_STACK_DUMP;
+  trid_t printBacktraceAtTraceNumber = MC_STATE_CONFIG_PRINT_AT_TRACE;
   bool firstDeadlock                  = false;
   bool expectForwardProgressOfThreads = false;
 
@@ -708,7 +708,7 @@ get_config_for_execution_environment()
   }
 
   if (getenv(ENV_PRINT_AT_TRACE_ID) != NULL) {
-    stackContentDumpTraceNumber =
+    printBacktraceAtTraceNumber =
       strtoul(getenv(ENV_PRINT_AT_TRACE_ID), nullptr, 10);
   }
   if (getenv(ENV_CHECK_FORWARD_PROGRESS) != NULL) {
@@ -719,8 +719,8 @@ get_config_for_execution_environment()
     firstDeadlock = true;
   }
 
-  return {maxThreadDepth, stackContentDumpTraceNumber,
-          firstDeadlock, expectForwardProgressOfThreads};
+  return {maxThreadDepth, printBacktraceAtTraceNumber, firstDeadlock,
+          expectForwardProgressOfThreads};
 }
 
 bool

--- a/src/transitions/barrier/MCBarrierEnqueue.cpp
+++ b/src/transitions/barrier/MCBarrierEnqueue.cpp
@@ -72,7 +72,7 @@ MCBarrierEnqueue::dependentWith(const MCTransition *other) const
 void
 MCBarrierEnqueue::print() const
 {
-  printf("thread %lu: pthread_barrier_wait(barr:%u) (enqueue)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->barrier->getObjectId()));
+  mcprintf("thread %lu: pthread_barrier_wait(barr:%u) (enqueue)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->barrier->getObjectId()));
 }

--- a/src/transitions/barrier/MCBarrierInit.cpp
+++ b/src/transitions/barrier/MCBarrierInit.cpp
@@ -76,8 +76,8 @@ MCBarrierInit::dependentWith(const MCTransition *other) const
 void
 MCBarrierInit::print() const
 {
-  printf("thread %lu: pthread_barrier_init(barr:%u, _, %u)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->barrier->getObjectId()),
-         this->barrier->getCount());
+  mcprintf("thread %lu: pthread_barrier_init(barr:%u, _, %u)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->barrier->getObjectId()),
+           this->barrier->getCount());
 }

--- a/src/transitions/barrier/MCBarrierWait.cpp
+++ b/src/transitions/barrier/MCBarrierWait.cpp
@@ -83,7 +83,7 @@ MCBarrierWait::enabledInState(const MCStack *state) const
 void
 MCBarrierWait::print() const
 {
-  printf("thread %lu: pthread_barrier_wait(barr:%u)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->barrier->getObjectId()));
+  mcprintf("thread %lu: pthread_barrier_wait(barr:%u)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->barrier->getObjectId()));
 }

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -152,7 +152,7 @@ MCCondBroadcast::dependentWith(const MCTransition *other) const
 void
 MCCondBroadcast::print() const
 {
-  const char * isLostWakeup = " [No thread waiting on cond; lost wakeup?]";
+  const char * isLostWakeup = " [Lost wakeup? (No thread waiting on cond) ]";
   if (hadWaiters) { isLostWakeup = ""; }
 
   printf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -155,7 +155,7 @@ MCCondBroadcast::print() const
   const char * isLostWakeup = " [Lost wakeup? (No thread waiting on cond) ]";
   if (hadWaiters) { isLostWakeup = ""; }
 
-  printf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,
-         countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
-         isLostWakeup);
+  mcprintf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,
+           countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+           isLostWakeup);
 }

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -230,8 +230,8 @@ MCCondEnqueue::dependentWith(const MCTransition *other) const
 void
 MCCondEnqueue::print() const
 {
-  printf("thread %lu: pthread_cond_wait(cond:%u, mut:%u) (awake -> asleep)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
-         countVisibleObjectsOfType(this->mutex->getObjectId()));
+  mcprintf("thread %lu: pthread_cond_wait(cond:%u, mut:%u) (awake -> asleep)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+           countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/cond/MCCondInit.cpp
+++ b/src/transitions/cond/MCCondInit.cpp
@@ -159,6 +159,6 @@ MCCondInit::dependentWith(const MCTransition *other) const
 void
 MCCondInit::print() const
 {
-  printf("thread %lu: pthread_cond_init(cond:%u, _)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
+  mcprintf("thread %lu: pthread_cond_init(cond:%u, _)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->conditionVariable->getObjectId()));
 }

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -156,7 +156,7 @@ MCCondSignal::dependentWith(const MCTransition *other) const
 void
 MCCondSignal::print() const
 {
-  const char * isLostWakeup = " [No thread waiting on cond; lost wakeup?]";
+  const char * isLostWakeup = " [Lost wakeup? (No thread waiting on cond) ]";
   if (hadWaiters) { isLostWakeup = ""; }
 
   printf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -159,7 +159,7 @@ MCCondSignal::print() const
   const char * isLostWakeup = " [Lost wakeup? (No thread waiting on cond) ]";
   if (hadWaiters) { isLostWakeup = ""; }
 
-  printf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,
-         countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
-         isLostWakeup);
+  mcprintf("thread %lu: pthread_cond_signal(cond:%u)%s\n", this->thread->tid,
+           countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+           isLostWakeup);
 }

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -142,8 +142,9 @@ MCCondWait::dependentWith(const MCTransition *other) const
 void
 MCCondWait::print() const
 {
-  printf("thread %lu: pthread_cond_wait(cond:%u, mut:%u) (asleep -> awake)\n",
-      this->thread->tid,
-      countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
-      countVisibleObjectsOfType(this->conditionVariable->mutex->getObjectId()));
+  mcprintf("thread %lu: pthread_cond_wait(cond:%u, mut:%u) (asleep -> awake)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->conditionVariable->getObjectId()),
+           countVisibleObjectsOfType(this->conditionVariable->mutex->
+                                                              getObjectId()));
 }

--- a/src/transitions/misc/MCAbortTransition.cpp
+++ b/src/transitions/misc/MCAbortTransition.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/misc/MCAbortTransition.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadAbortTransition(const MCSharedTransition *shmTransition,
@@ -46,7 +47,7 @@ MCAbortTransition::enabledInState(const MCStack *) const
 void
 MCAbortTransition::print() const
 {
-  printf("thread %lu: abort()\n", this->thread->tid);
+  mcprintf("thread %lu: abort()\n", this->thread->tid);
 }
 
 bool

--- a/src/transitions/misc/MCExitTransition.cpp
+++ b/src/transitions/misc/MCExitTransition.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/misc/MCExitTransition.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadExitTransition(const MCSharedTransition *shmTransition,
@@ -44,7 +45,7 @@ MCExitTransition::enabledInState(const MCStack *) const
 void
 MCExitTransition::print() const
 {
-  printf("thread %lu: exit(%u)\n", this->thread->tid, this->exitCode);
+  mcprintf("thread %lu: exit(%u)\n", this->thread->tid, this->exitCode);
 }
 
 bool

--- a/src/transitions/misc/MCGlobalVariableRead.cpp
+++ b/src/transitions/misc/MCGlobalVariableRead.cpp
@@ -1,5 +1,6 @@
 #include "mcmini/transitions/misc/MCGlobalVariableRead.h"
 #include "mcmini/transitions/misc/MCGlobalVariableWrite.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadGlobalRead(const MCSharedTransition *shmTransition,
@@ -77,6 +78,6 @@ MCGlobalVariableRead::isRacingWith(
 void
 MCGlobalVariableRead::print() const
 {
-  printf("thread %lu: READ(%p)\n", this->thread->tid,
-         this->global->addr);
+  mcprintf("thread %lu: READ(%p)\n", this->thread->tid,
+           this->global->addr);
 }

--- a/src/transitions/misc/MCGlobalVariableWrite.cpp
+++ b/src/transitions/misc/MCGlobalVariableWrite.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/misc/MCGlobalVariableWrite.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadGlobalWrite(const MCSharedTransition *shmTransition,
@@ -84,6 +85,6 @@ MCGlobalVariableWrite::isRacingWith(
 void
 MCGlobalVariableWrite::print() const
 {
-  printf("thread %lu: WRITE(%p, %p)\n", this->thread->tid,
-         this->global->addr, this->newValue);
+  mcprintf("thread %lu: WRITE(%p, %p)\n", this->thread->tid,
+           this->global->addr, this->newValue);
 }

--- a/src/transitions/mutex/MCMutexInit.cpp
+++ b/src/transitions/mutex/MCMutexInit.cpp
@@ -87,7 +87,7 @@ MCMutexInit::dependentWith(const MCTransition *other) const
 void
 MCMutexInit::print() const
 {
-  printf("thread %lu: pthread_mutex_init(mut:%u, _)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->mutex->getObjectId()));
+  mcprintf("thread %lu: pthread_mutex_init(mut:%u, _)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/mutex/MCMutexLock.cpp
+++ b/src/transitions/mutex/MCMutexLock.cpp
@@ -176,6 +176,6 @@ MCMutexLock::dependentWith(const MCTransition *transition) const
 void
 MCMutexLock::print() const
 {
-  printf("thread %lu: pthread_mutex_lock(mut:%u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->mutex->getObjectId()));
+  mcprintf("thread %lu: pthread_mutex_lock(mut:%u)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/mutex/MCMutexUnlock.cpp
+++ b/src/transitions/mutex/MCMutexUnlock.cpp
@@ -90,6 +90,6 @@ MCMutexUnlock::dependentWith(const MCTransition *transition) const
 void
 MCMutexUnlock::print() const
 {
-  printf("thread %lu: pthread_mutex_unlock(mut:%u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->mutex->getObjectId()));
+  mcprintf("thread %lu: pthread_mutex_unlock(mut:%u)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->mutex->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockInit.cpp
+++ b/src/transitions/rwlock/MCRWLockInit.cpp
@@ -73,6 +73,6 @@ MCRWLockInit::dependentWith(const MCTransition *other) const
 void
 MCRWLockInit::print() const
 {
-  printf("thread %lu: pthread_rwlock_init(rwl:%u, _)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->rwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_init(rwl:%u, _)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
@@ -76,7 +76,7 @@ MCRWLockReaderEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWLockReaderEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwlock_rdlock(rwl:%u) (wait)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_rdlock(rwl:%u) (wait)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockReaderLock.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderLock.cpp
@@ -155,7 +155,7 @@ MCRWLockReaderLock::dependentWith(const MCTransition *other) const
 void
 MCRWLockReaderLock::print() const
 {
-  printf("thread %lu: pthread_rwlock_rdlock(rwl:%u) (lock)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_rdlock(rwl:%u) (lock)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockUnlock.cpp
+++ b/src/transitions/rwlock/MCRWLockUnlock.cpp
@@ -75,6 +75,6 @@ MCRWLockUnlock::dependentWith(const MCTransition *other) const
 void
 MCRWLockUnlock::print() const
 {
-  printf("thread %lu: pthread_rwlock_unlock(rwl:%u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->rwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_unlock(rwl:%u)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
@@ -76,7 +76,7 @@ MCRWLockWriterEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWLockWriterEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwlock_wrlock(rwl:%u) (wait)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_wrlock(rwl:%u) (wait)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwlock/MCRWLockWriterLock.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterLock.cpp
@@ -151,7 +151,7 @@ MCRWLockWriterLock::dependentWith(const MCTransition *other) const
 void
 MCRWLockWriterLock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wrlock(rwl:%u) (lock)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_wrlock(rwl:%u) (lock)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockInit.cpp
+++ b/src/transitions/rwwlock/MCRWWLockInit.cpp
@@ -71,6 +71,6 @@ MCRWWLockInit::dependentWith(const MCTransition *other) const
 void
 MCRWWLockInit::print() const
 {
-  printf("thread %lu: pthread_rwwlock_init(rwwl:%u, _)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwwlock_init(rwwl:%u, _)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
@@ -76,7 +76,7 @@ MCRWWLockReaderEnqueue::dependentWith(const MCTransition *other) const
 void
 MCRWWLockReaderEnqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_rdlock(rwwl:%u) (wait)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwwlock_rdlock(rwwl:%u) (wait)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
@@ -106,7 +106,7 @@ MCRWWLockReaderLock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockReaderLock::print() const
 {
-  printf("thread %lu: pthread_rwwlock_rdlock(rwwl:%u) (lock)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwwlock_rdlock(rwwl:%u) (lock)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockUnlock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockUnlock.cpp
@@ -75,7 +75,7 @@ MCRWWLockUnlock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockUnlock::print() const
 {
-  printf("thread %lu: pthread_rwwlock_unlock(rwwl:%u)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwwlock_unlock(rwwl:%u)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
@@ -79,7 +79,7 @@ MCRWWLockWriter1Enqueue::dependentWith(
 void
 MCRWWLockWriter1Enqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_wr1lock(rwl:%u) (wait)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwwlock_wr1lock(rwl:%u) (wait)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
@@ -101,7 +101,7 @@ MCRWWLockWriter1Lock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockWriter1Lock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wr1lock(rwwl:%u) (lock)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_wr1lock(rwwl:%u) (lock)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
@@ -79,7 +79,7 @@ MCRWWLockWriter2Enqueue::dependentWith(
 void
 MCRWWLockWriter2Enqueue::print() const
 {
-  printf("thread %lu: pthread_rwwlock_wr2lock(rwwl:%u) (wait)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwwlock_wr2lock(rwwl:%u) (wait)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
@@ -101,7 +101,7 @@ MCRWWLockWriter2Lock::dependentWith(const MCTransition *other) const
 void
 MCRWWLockWriter2Lock::print() const
 {
-  printf("thread %lu: pthread_rwlock_wr2lock(rwwl:%u) (lock)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->rwwlock->getObjectId()));
+  mcprintf("thread %lu: pthread_rwlock_wr2lock(rwwl:%u) (lock)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->rwwlock->getObjectId()));
 }

--- a/src/transitions/semaphore/MCSemEnqueue.cpp
+++ b/src/transitions/semaphore/MCSemEnqueue.cpp
@@ -91,7 +91,7 @@ MCSemEnqueue::dependentWith(const MCTransition *other) const
 void
 MCSemEnqueue::print() const
 {
-  printf("thread %lu: sem_wait(sem:%u) (awake -> asleep)\n",
-         this->thread->tid,
-         countVisibleObjectsOfType(this->sem->getObjectId()));
+  mcprintf("thread %lu: sem_wait(sem:%u) (awake -> asleep)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->sem->getObjectId()));
 }

--- a/src/transitions/semaphore/MCSemInit.cpp
+++ b/src/transitions/semaphore/MCSemInit.cpp
@@ -70,7 +70,7 @@ MCSemInit::dependentWith(const MCTransition *other) const
 void
 MCSemInit::print() const
 {
-  printf("thread %lu: sem_init(sem:%u, 0, %u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->sem->getObjectId()),
-         this->sem->getCount());
+  mcprintf("thread %lu: sem_init(sem:%u, 0, %u)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->sem->getObjectId()),
+           this->sem->getCount());
 }

--- a/src/transitions/semaphore/MCSemPost.cpp
+++ b/src/transitions/semaphore/MCSemPost.cpp
@@ -75,6 +75,6 @@ MCSemPost::dependentWith(const MCTransition *other) const
 void
 MCSemPost::print() const
 {
-  printf("thread %lu: sem_post(sem:%u)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->sem->getObjectId()));
+  mcprintf("thread %lu: sem_post(sem:%u)\n", this->thread->tid,
+           countVisibleObjectsOfType(this->sem->getObjectId()));
 }

--- a/src/transitions/semaphore/MCSemWait.cpp
+++ b/src/transitions/semaphore/MCSemWait.cpp
@@ -89,6 +89,7 @@ MCSemWait::enabledInState(const MCStack *) const
 void
 MCSemWait::print() const
 {
-  printf("thread %lu: sem_wait(sem:%u) (asleep -> awake)\n", this->thread->tid,
-         countVisibleObjectsOfType(this->sem->getObjectId()));
+  mcprintf("thread %lu: sem_wait(sem:%u) (asleep -> awake)\n",
+           this->thread->tid,
+           countVisibleObjectsOfType(this->sem->getObjectId()));
 }

--- a/src/transitions/threads/MCThreadCreate.cpp
+++ b/src/transitions/threads/MCThreadCreate.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/threads/MCThreadCreate.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadThreadCreate(const MCSharedTransition *shmTransition,
@@ -95,6 +96,6 @@ MCThreadCreate::doesCreateThread(tid_t tid) const
 void
 MCThreadCreate::print() const
 {
-  printf("thread %lu: pthread_create(thr:%lu, _, _, _)\n", this->thread->tid,
-         this->target->tid);
+  mcprintf("thread %lu: pthread_create(thr:%lu, _, _, _)\n", this->thread->tid,
+           this->target->tid);
 }

--- a/src/transitions/threads/MCThreadFinish.cpp
+++ b/src/transitions/threads/MCThreadFinish.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/threads/MCThreadFinish.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadThreadFinish(const MCSharedTransition *shmTransition,
@@ -75,7 +76,7 @@ MCThreadFinish::dependentWith(const MCTransition *transition) const
 void
 MCThreadFinish::print() const
 {
-  printf("thread %lu: exits\n", this->thread->tid);
+  mcprintf("thread %lu: exits\n", this->thread->tid);
 }
 
 bool

--- a/src/transitions/threads/MCThreadJoin.cpp
+++ b/src/transitions/threads/MCThreadJoin.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/threads/MCThreadJoin.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadThreadJoin(const MCSharedTransition *shmTransition,
@@ -115,6 +116,6 @@ MCThreadJoin::joinsOnThread(
 void
 MCThreadJoin::print() const
 {
-  printf("thread %lu: pthread_join(thr:%lu, _)\n", this->thread->tid,
-         this->target->tid);
+  mcprintf("thread %lu: pthread_join(thr:%lu, _)\n", this->thread->tid,
+           this->target->tid);
 }

--- a/src/transitions/threads/MCThreadStart.cpp
+++ b/src/transitions/threads/MCThreadStart.cpp
@@ -1,4 +1,5 @@
 #include "mcmini/transitions/threads/MCThreadStart.h"
+#include "mcmini/mcmini_private.h"  /* For mcprintf() */
 
 MCTransition *
 MCReadThreadStart(const MCSharedTransition *shmTransition,
@@ -67,7 +68,7 @@ MCThreadStart::dependentWith(const MCTransition *transition) const
 void
 MCThreadStart::print() const
 {
-  printf("thread %lu: starts\n", this->thread->tid);
+  mcprintf("thread %lu: starts\n", this->thread->tid);
 }
 
 bool

--- a/src/transitions/wrappers/MCSharedLibraryWrappers.c
+++ b/src/transitions/wrappers/MCSharedLibraryWrappers.c
@@ -10,6 +10,7 @@ typeof(&pthread_mutex_unlock) pthread_mutex_unlock_ptr;
 typeof(&sem_wait) sem_wait_ptr;
 typeof(&sem_post) sem_post_ptr;
 typeof(&sem_init) sem_init_ptr;
+typeof(&sem_destroy) sem_destroy_ptr;
 typeof(&exit) exit_ptr;
 typeof(&abort) abort_ptr;
 typeof(&pthread_barrier_init) pthread_barrier_init_ptr;
@@ -36,6 +37,7 @@ mc_load_intercepted_symbol_addresses()
   sem_wait_ptr             = dlsym(RTLD_NEXT, "sem_wait");
   sem_post_ptr             = dlsym(RTLD_NEXT, "sem_post");
   sem_init_ptr             = dlsym(RTLD_NEXT, "sem_init");
+  sem_destroy_ptr          = dlsym(RTLD_NEXT, "sem_destroy");
   exit_ptr                 = dlsym(RTLD_NEXT, "exit");
   abort_ptr                = dlsym(RTLD_NEXT, "abort");
   pthread_barrier_init_ptr = dlsym(RTLD_NEXT, "pthread_barrier_init");
@@ -62,6 +64,7 @@ mc_load_intercepted_symbol_addresses()
   sem_post_ptr               = &sem_post;
   sem_wait_ptr               = &sem_wait;
   sem_init_ptr               = &sem_init;
+  sem_destroy_ptr            = &sem_destroy;
   exit_ptr                   = &exit;
   abort_ptr                  = &abort;
   pthread_barrier_init_ptr   = &pthread_barrier_init;


### PR DESCRIPTION
The McMini src now has two functions, `mcprintf_redirect()` and `mcprintf_stop_redirect()`, which temporarily redirect mcprintf stdout` to a buffer, `mcprintf_redirect_output`.

In gdbinit_commands.py, the functions `redirect_prolog` and `redirect_epilog` capture all stdout in between, and grab it in Python using: 
> output = gdb.parse_and_eval("mcprintf_redirect_output").string()

The main files to review are `src/MCCommon.c` and `gdbinit_commands.py`.  Those parts are short and simple.  The goal is for mcprintf to print to an output array (`mcprintf_out`), and that array can then be printed to the screen later by Python.  This is important because we need to capture things like "pending transitions" when we are in `inferior 1` (the model or scheduler), but then display it only when GDB is back in the user/target program

Everything else is changing 'printf' to 'mcprintf' everywhere.  Presumably, that was the original intention anyway.  (The scheduler with the model should be using `mcprintf` instead of `printf`.)