### PR TITLE
Minor cleanups

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ LIBOBJS4=src/transitions/barrier/MCBarrierEnqueue.o src/transitions/barrier/MCBa
 LIBOBJS=${LIBOBJS1} ${LIBOBJS2} ${LIBOBJS3} ${LIBOBJS4} \
        	src/mc_shared_sem.o src/MCCommon.o src/main.o
 
-all: mcmini libmcmini.so mcmini-demo NO-GDB-G3
+all: mcmini libmcmini.so NO-GDB-G3
 
 # If '-g3' is not a part of ${CFLAGS}, then create file NO-GDB-G3
 NO-GDB-G3:

--- a/gdbinit
+++ b/gdbinit
@@ -7,7 +7,12 @@ set pagination off
 # GDB will track both parent and child
 set detach-on-fork off
 set print pretty
-set print address off
+## set print address off
+###############################################
+# Consider this for more silent operation, but add back for developer mode
+## set print frame-info off
+## set print inferior-events off # This appears with new trace; Maybe set it off for 'mcmini back'
+## set print symbol-loading off
 # In McMini, parent sends SIGUSR1 to child on exit.
 handle SIGUSR1 nostop noprint pass
 handle SIGUSR2 nostop noprint pass
@@ -99,4 +104,4 @@ continue
 # Print Python-based GDB commands:
 help user-defined
 echo \n\ \ *** Type 'mcmini help' for usage. ***\n
-echo     \ \ (Do 'set print address on' for more verbose outpus.)\n\n
+echo     \ \ (Do 'set print address off' for less verbose output.)\n\n

--- a/gdbinit_commands.py
+++ b/gdbinit_commands.py
@@ -243,7 +243,7 @@ class forwardCmd(gdb.Command):
       print("GDB is in scheduler, not target process:" +
             "  Can't go to next transition\n")
       return
-    # GDB based on Red Hat use debuginfo files.  This will suppress
+    # GDB based on Red Hat uses debuginfo files.  This will suppress
     # the warning.  However, this GDB command fails on Debian-based distros,
     # and anyway, no warning about missing debug files issued.
     try:

--- a/src/export/rwwlock.c
+++ b/src/export/rwwlock.c
@@ -1,26 +1,27 @@
 #include "mcmini/export/rwwlock.h"
 
 // This proves that McMini behaves as an emulator:
-// we don't even need to define implementations
-// for the true function calls here. As long as
-// McMini has the semantics correct, it will
-// just work!
+// A user can link this code into the target application.  We don't even need
+// to define an implementation for when the target calls the functions here.
+// McMini already models these functions as desired, and will continue
+// to block or unblock threads according to a spec analogous to rwlock
+// for POSIX.  Since McMini has the semantics correct, it will just work!
 
 int
 pthread_rwwlock_init(pthread_rwwlock_t *rwwlock)
-{}
+{ return 0; }
 int
 pthread_rwwlock_rdlock(pthread_rwwlock_t *rwwlock)
-{}
+{ return 0; }
 int
 pthread_rwwlock_wr1lock(pthread_rwwlock_t *rwwlock)
-{}
+{ return 0; }
 int
 pthread_rwwlock_wr2lock(pthread_rwwlock_t *rwwlock)
-{}
+{ return 0; }
 int
 pthread_rwwlock_unlock(pthread_rwwlock_t *rwwlock)
-{}
+{ return 0; }
 int
 pthread_rwwlock_destroy(pthread_rwwlock_t *rwwlock)
-{}
+{ return 0; }


### PR DESCRIPTION
Minor; easy review

1. Stop compiler warning for `mcmini/export/rwwlock.h` and improve comment
2. Stop building 'mcmini-demo' by default.  `make mcmini-demo` still works if desired.
3. Small number of random improved comments or msg to user