### PR TITLE
Remove obfuscation from MC_STRUCT_DECL

### DIFF
--- a/include/mcmini/MCShared.h
+++ b/include/mcmini/MCShared.h
@@ -66,10 +66,5 @@ typedef void *MCSystemID;
 #endif
 
 #define MC_FATAL() abort()
-#define MC_STRUCT_DECL(type)       \
-  typedef struct type type;        \
-  typedef struct type *type##_t;   \
-  typedef struct type *type##_ref; \
-  typedef const struct type *type##_refc;
 
 #endif // DPOR_MCSHARED_H

--- a/include/mcmini/mc_shared_sem.h
+++ b/include/mcmini/mc_shared_sem.h
@@ -4,11 +4,22 @@
 #include "mcmini/MCShared.h"
 #include <semaphore.h>
 
-MC_STRUCT_DECL(mc_shared_sem)
+// NOTE: We have a semaphore pair for each thread.  trace_sleep_list
+//       is an array of mc_shared_sem (no relation to sleep sets).
+//  1. The scheduler posts to a pthread_sem for Thread X.
+//  2. The scheduler then waits on the dpor_scheduler_sem for Thread X.
+//  3. Thread X advances to the next visible operation and then
+//       posts to the dpor_scheduler_sem for Thread X.
+//  4. Thread X then waits on pthread_sem.
+//  5. The scheduler can now decide to post to some new thread, Thread Y.
+// NOTE: There is also a separate semaphore for each thread: _create_binary_sem
+//       When the scheduler creates a thread, it waits on this semaphore,
+//       and the newly created thread then posts on this to the scheduler.
 struct mc_shared_sem {
-  sem_t dpor_scheduler_sem;
-  sem_t pthread_sem;
+  sem_t dpor_scheduler_sem; // scheduler waits on this; target posts
+  sem_t pthread_sem; // target waits on this; scheduler posts
 };
+typedef struct mc_shared_sem *mc_shared_sem_ref;
 
 void mc_shared_sem_init(mc_shared_sem_ref);
 void mc_shared_sem_destroy(mc_shared_sem_ref);


### PR DESCRIPTION
The macro MC_STRUCT_DEF was defined in MCShared.h, and used in mc_shared_sem.h.
The macro is used once only, as:  MC_STRUCT_DEF(mc_shared_sem).
The macro is used to define four types:

> typedef struct mc_shared_sem mc_shared_sem;
> typedef struct mc_shared_sem *mc_shared_sem_t;
> typedef const struct mc_shared_sem *mc_shared_sem_refc;
> typedef struct mc_shared_sem *mc_shared_sem_ref;

The first three types are never used.  The fourth type is now used directly in mc_shared_sem.h, and we remove the remaining text.  This seems to be motivated by the C++ philosophy of hiding all type declarations..  The obfuscation seems to have the purpose that if someone greps for 'mc_shared_sem_ref, they will not find it.

(In general, McMini currently uses five types of semaphores:  mc_shared_sem_ref (dpor_scheduler_sem and pthread_sem), mc_pthread,_create_binary_sem;  and trace_sleep_list.)

**EXPLANATION:** There is an `mc_shared_sem_ref` for each thread of the target process.  The target posts to `dpor_scheduler_sem`, and the scheduler posts to `pthred_sem`.  For `mc_pthread_create_binary_sem`, there is one for each thread *slot* (for each of the maximum number of threads).  And `trace_sleep_list` is a pointer to an array of `mc_shared_sem_ref` (which allows us to malloc just once).  See PR #129, which will allow one to 'grep' for`mc_shared_sem_ref`.  At every new branch, we do a sem_destroy and sem_init of all semaphores.