### PR TITLE
Use a weak symbol to detect if in record mode

### DIFF
--- a/dmtcp/src/lib/dmtcp-callback.c
+++ b/dmtcp/src/lib/dmtcp-callback.c
@@ -12,6 +12,10 @@
 #include "mcmini/spy/checkpointing/rec_list.h"
 #include "mcmini/spy/intercept/interception.h"
 
+// We probably won't need the '#undef', but just in case a .h file defined it:
+#undef dmtcp_mcmini_is_loaded
+int dmtcp_mcmini_is_loaded() { return 1; }
+
 static atomic_bool is_template_thread_alive = 0;
 
 static void *template_thread(void *unused) {

--- a/dmtcp/src/lib/main.c
+++ b/dmtcp/src/lib/main.c
@@ -61,15 +61,18 @@ void mc_deallocate_shared_memory_region(void) {
   }
 }
 
+int dmtcp_mcmini_plugin_is_loaded(void) __attribute((weak));
+#define dmtcp_mcmini_plugin_is_loaded() \
+  (dmtcp_mcmini_plugin_is_loaded? dmtcp_mcmini_plugin_is_loaded() : 0)
+
 __attribute__((constructor)) void libmcmini_main() {
   // In recording mode, the constructor should be ignored and
   // the DMTCP callback should instead be used to determine when
   // `libmcmini.so` wrappers should begin recording.
 
-  // TODO: With weak and strong variables we can later detect
-  // whether `libmcmini` has been loaded as a plugin.
-  // McMini is only loaded as a plugin in record mode.
-  if (dmtcp_is_enabled()) {
+  if (dmtcp_mcmini_plugin_is_loaded()) {
+    // The libmcmini plugin of DMTCP has been loaded.
+    // We must be in recording mode.  Don't do model checking yet.
     return;
   }
   mc_prevent_addr_randomization();

--- a/dmtcp/src/mcmini/mcmini.cpp
+++ b/dmtcp/src/mcmini/mcmini.cpp
@@ -203,6 +203,7 @@ void do_model_checking_from_dmtcp_ckpt_file(const config& config) {
 
 void do_recording(const config& config) {
   char dir[PATH_MAX];
+  // FIXME:  This depends on mcmini starting in root dir of git repo.
   std::string libmcini_dir = getcwd(dir, sizeof(dir)) ? dir : "PATH_TOO_LONG";
   std::string libmcmini_path = libmcini_dir + "/libmcmini.so";
   std::vector<std::string> dmtcp_launch_args;


### PR DESCRIPTION
We will be in record mode only if the DMTCP McMini plugin, libmcmini, was loaded.  libmcmini will create a strong symbol, dmtcp_mcmini_is_loaded, to override the existing weak symbol, if it has been loaded.