### PR TITLE
Fix Broken CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.10)
 project(McMini
-    VERSION 0.0.1
+    VERSION 1.0.0
     DESCRIPTION "A bite-sized model checker"
-    LANGUAGES C CXX)
+    LANGUAGES C CXX
+    HOMEPAGE_URL https://github.com/mcminickpt/mcmini.git
+)
 
 # C and C++ Versions
+set(HAVE_CXX11 TRUE)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
@@ -20,6 +23,12 @@ set(MCMINI_SCRIPTS_DIR "${CMAKE_SOURCE_DIR}/script")
 set(MCMINI_DOCS_DIR "${CMAKE_SOURCE_DIR}/docs")
 set(MCMINI_GOOGLE_TEST_DIR "${CMAKE_SOURCE_DIR}/external/googletest")
 set(MCMINI_GOOGLE_TEST_INCLUDE_DIR "${MCMINI_GOOGLE_TEST_DIR}/include")
+set(PACKAGE_NAME "McMini")
+set(PACKAGE_TARNAME "mcmini")
+set(PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
+set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+set(PACKAGE_BUGREPORT "pirtle.m\@northeastern.edu,jovanovic.l\@northeastern.edu,gene\@ccs.neu.edu")
+set(PACKAGE_URL "${CMAKE_PROJECT_HOMEPAGE_URL}")
 
 # Include the "cmake/" directory as a location to look for CMake modules
 list(APPEND CMAKE_MODULE_PATH "${MCMINI_CMAKE_MODULE_DIR}")
@@ -35,6 +44,9 @@ include(ConfigureScripts)
 add_subdirectory(src)
 add_subdirectory(external)
 add_subdirectory_if(BUILD_TESTS "Tests only built with BUILD_TESTS=1" tests)
+
+# Configure
+configure_file(config.cmake "${CMAKE_SOURCE_DIR}/include/config.h")
 
 # CTest setup
 enable_testing()

--- a/cmake/GitSubmodule.cmake
+++ b/cmake/GitSubmodule.cmake
@@ -1,6 +1,6 @@
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-    option(INIT_SUBMODULE "Checkout submodules during build" ON)
+    option(INIT_SUBMODULE "Checkout submodules during build" OFF)
     if(INIT_SUBMODULE)
         message(STATUS "Initializing git submodules")
         execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive

--- a/config.cmake
+++ b/config.cmake
@@ -1,0 +1,25 @@
+/* include/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have process_vm_readv and process_vm_writev. */
+#cmakedefine HAS_PROCESS_VM
+
+/* define if the compiler supports basic C++14 syntax */
+#cmakedefine HAVE_CXX11
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME "@PACKAGE_NAME@"
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME "@PACKAGE_TARNAME@"
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL "@PACKAGE_URL@"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION "@PACKAGE_VERSION@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,15 +6,16 @@ set(MC_C_FILES
 )
 
 set(MC_CPP_FILES
-  MCObjectStore.cpp
-  MCSharedTransition.cpp
-  MCTransition.cpp
-  MCState.cpp
-  MCTransitionFactory.cpp
-  MCStateStackItem.cpp
-  MCThreadData.cpp
+  main.cpp
   MCClockVector.cpp
   mcmini_private.cpp
+  MCObjectStore.cpp
+  MCSharedTransition.cpp
+  MCStack.cpp
+  MCStackItem.cpp
+  MCThreadData.cpp
+  MCTransition.cpp
+  MCTransitionFactory.cpp
   signals.cpp
 
   misc/cond/MCConditionVariableDefaultPolicy.cpp


### PR DESCRIPTION
## Overview

This commit fixes the broken CMake configuration for McMini. The key idea here is the use of [`configure_file`](https://cmake.org/cmake/help/latest/command/configure_file.html) which behaves mostly like `config.in`. The difference is the use of `#cmakedefine` which CMake itself interprets. Essentially `#cmakedefine`  turns into exactly as you'd expect (`#undef`/`#define` as in the standard `config.h`).

### Verify the Build

Running 

```shell
cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j3
```

should now work as expected.
