### PR TITLE
Fix deadlock bug

### DIFF
--- a/include/transitions/wrappers/MCSharedLibraryWrappers.h
+++ b/include/transitions/wrappers/MCSharedLibraryWrappers.h
@@ -61,7 +61,7 @@ extern typeof(&sleep) sleep_ptr;
  * McMini re-defines and exports symbols defined in other dynamic
  * libraries to change the behavior of a program which is dynamically
  * linked to the libraries containing those symbols. When McMini as a
- * dynamic libarary is pre-loaded into memory, a process making calls
+ * dynamic library is pre-loaded into memory, a process making calls
  * to the dynamic library will result in McMini's symbols being
  * dynamically chosen instead.
  *

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -414,16 +414,23 @@ MCStack::isInDeadlock() const
     const MCTransition &nextTransitionForTid =
       this->getNextTransitionForThread(tid);
 
-    if (nextTransitionForTid.ensuresDeadlockIsImpossible())
+    if (this->getThreadDataForThread(tid).getExecutionDepth() >=
+        this->configuration.maxThreadExecutionDepth) {
       return false;
+    }
+
+    if (nextTransitionForTid.ensuresDeadlockIsImpossible()) {
+      return false;
+    }
 
     // We don't use the wrapper here (this->transitionIsEnabled)
     // because we only care about if the schedule *could* keep going:
     // we wouldn't be in deadlock if we artificially restricted the
     // threads
     if (MCTransition::transitionEnabledInState(this,
-                                               nextTransitionForTid))
+                                               nextTransitionForTid)) {
       return false;
+    }
   }
   return true;
 }

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -591,7 +591,7 @@ MCStack::dynamicallyUpdateBacktrackSets()
         mostRecentThreadId);
     /*
      * Stop when we find the first such i; this
-     * will be the maxmimum `i` since we're searching
+     * will be the maximum `i` since we're searching
      * backwards
      */
     if (shouldStop) break;

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -288,7 +288,7 @@ mc_explore_branch(int curBranchPoint)
   traceId++;
   if (false && traceId >= 1 && getenv(ENV_PRINT_AT_TRACE_SEQ) != NULL) {
     mcprintf("*** Trace sequence ('-t', --trace') requested.\n"
-             "*** for more than one traceDd: -t<X> -t'<traceSeq>' for X>0\n"
+             "*** for more than one traceId: -t<X> -t'<traceSeq>' for X>0\n"
              "*** McMini cannot yet handle this situation.  Exiting now.\n");
     mc_exit(EXIT_FAILURE);
   }

--- a/src/misc/cond/MCConditionVariableDefaultPolicy.cpp
+++ b/src/misc/cond/MCConditionVariableDefaultPolicy.cpp
@@ -20,7 +20,7 @@ ConditionVariableDefaultPolicy::receive_broadcast_message()
 bool
 ConditionVariableDefaultPolicy::has_waiters() const
 {
-  // broadcast_eligiblle_threads are those threads that were
+  // broadcast_eligible_threads are those threads that were
   //   blocked, but were around during the last broadcast.
   // wake_groups are the groups that are available to wake.
   return ! this->broadcast_eligible_threads.empty() ||

--- a/src/objects/MCThread.cpp
+++ b/src/objects/MCThread.cpp
@@ -1,7 +1,7 @@
 #include "objects/MCThread.h"
 
 static_assert(MC_IS_TRIVIALLY_COPYABLE(MCThreadShadow),
-              "The shared transition is not trivially copiable. "
+              "The shared transition is not trivially copyable. "
               "Performing a memcpy of this type "
               "is undefined behavior according to the C++ standard.");
 

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -79,7 +79,7 @@ MCCondWait::applyToState(MCStack *state)
   const tid_t threadId = this->getThreadId();
   this->conditionVariable->mutex->lock(threadId);
   this->conditionVariable->removeWaiter(threadId);
-  // POSIX sttandard says that the dynamic binding of a condition variable
+  // POSIX standard says that the dynamic binding of a condition variable
   // to a mutex is removed when the last thread waiting on that cond var is
   // unblocked (i.e., has re-acquired the associated mutex of the cond var).
   if (! this->conditionVariable->hasWaiters()) {


### PR DESCRIPTION
In Mcmini, if one thread was at its maximum depth, as per `--max-depth-per-thread`, and the other threads were "Blocked", then McMini reported this as deadlock.  This was especially serious with the `--first` argument.  This fixes it (and fixes some spelling errors.)