### PR TITLE
Change in condition variable

### DIFF
--- a/dmtcp/include/mcmini/model/transitions/condition_variables/condition_variable_enqueue_thread.hpp
+++ b/dmtcp/include/mcmini/model/transitions/condition_variables/condition_variable_enqueue_thread.hpp
@@ -28,6 +28,10 @@ struct condition_variable_enqueue_thread : public model::transition{
       return status::disabled;
     }
 
+    if(!m->is_locked_by(executor)) {
+      return status::disabled;
+    }
+
     condition_variable_status current_state = cv->get_policy()->get_thread_cv_state(executor);
     if (current_state == CV_PREWAITING) {
     // Thread not fully in wait state - update to WAITING before proceeding

--- a/dmtcp/src/mcmini/mcmini.cpp
+++ b/dmtcp/src/mcmini/mcmini.cpp
@@ -521,6 +521,12 @@ int main_cpp(int argc, const char** argv) {
       exit(1);
     }
     mcmini_config.target_executable = std::string(cur_arg[0]);
+    // Collect all remaining arguments as target executable arguments
+    cur_arg++;
+    while (cur_arg[0] != NULL) {
+      mcmini_config.target_executable_args.push_back(std::string(cur_arg[0]));
+      cur_arg++;
+    }
   }
 
   install_process_wide_signal_handlers();


### PR DESCRIPTION
This PR added a missing condition for condition variables at the model side. Without this condition, the model was not able to return that we are in deadlock if the initial state was a deadlock state at the time of restart.