### PR TITLE
Avoid race b/w read/write shm_global_variable

### DIFF
--- a/dmtcp/include/mcmini/common/shm_config.h
+++ b/dmtcp/include/mcmini/common/shm_config.h
@@ -6,6 +6,7 @@ extern "C" {
 
 #include <stddef.h>
 #include <stdint.h>
+#include <pthread.h>
 
 #include "mcmini/defines.h"
 #include "mcmini/real_world/mailbox/runner_mailbox.h"
@@ -14,6 +15,14 @@ extern "C" {
 
 const extern size_t shm_size;
 void mc_get_shm_handle_name(char *dst, size_t sz);
+
+// Declare the global variable and the mutex
+extern volatile void* global_shm_start;
+extern pthread_mutex_t shm_start_mutex;
+
+// Function declarations
+void set_global_shm_start(void* addr);
+volatile void* get_global_shm_start();
 
 struct mcmini_shm_file {
   struct template_process_t tpt;

--- a/dmtcp/src/common/shm_config.c
+++ b/dmtcp/src/common/shm_config.c
@@ -14,3 +14,26 @@ void mc_get_shm_handle_name(char *dst, size_t sz) {
   snprintf(dst, sz, "/mcmini-%s-%lu", getenv("USER"), (long)getppid());
   dst[sz - 1] = '\0';
 }
+
+// Define the global variable and initialize the mutex
+volatile void* global_shm_start = NULL;
+pthread_mutex_t shm_start_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Function to set the global shared memory start address
+void set_global_shm_start(void* addr) {
+    pthread_mutex_lock(&shm_start_mutex);
+    global_shm_start = addr;
+    pthread_mutex_unlock(&shm_start_mutex);
+}
+
+// Function to get the global shared memory start address
+volatile void* get_global_shm_start() {
+    // Use a thread-local variable to cache the value
+    static __thread volatile void* local_shm_start = NULL;
+
+    if (local_shm_start == NULL) {
+        local_shm_start = global_shm_start;
+    }
+
+    return local_shm_start;
+}

--- a/dmtcp/src/lib/main.c
+++ b/dmtcp/src/lib/main.c
@@ -17,8 +17,6 @@
 #include "dmtcp.h"
 #include "mcmini/mcmini.h"
 
-volatile void *global_shm_start = NULL;
-
 void mc_allocate_shared_memory_region(const char *shm_name) {
   int fd = shm_open(shm_name, O_RDWR, S_IRUSR | S_IWUSR);
   if (fd == -1) {
@@ -43,7 +41,7 @@ void mc_allocate_shared_memory_region(const char *shm_name) {
   }
   fsync(fd);
   close(fd);
-  global_shm_start = gshms;
+  set_global_shm_start(gshms);
 }
 
 void mc_deallocate_shared_memory_region(void) {

--- a/dmtcp/src/lib/wrappers.c
+++ b/dmtcp/src/lib/wrappers.c
@@ -65,7 +65,7 @@ volatile runner_mailbox *thread_get_mailbox() {
   assert(!is_checkpoint_thread());
   assert(tid_self != RID_INVALID);
   assert(tid_self != RID_CHECKPOINT_THREAD);
-  return &((volatile struct mcmini_shm_file *)(global_shm_start))
+  return &((volatile struct mcmini_shm_file *)(get_global_shm_start()))
               ->mailboxes[tid_self];
 }
 


### PR DESCRIPTION
Added a function to write shm_global_variable address which is protected by the mutexes. Another function to read shm_global_variable with a thread local variable to make sure it read only once. This way we avoid the race happening between reading and writing of this shared global variable.