### PR TITLE
Added a new struct, MCTransitionUniqueRep

### DIFF
--- a/include/MCStack.h
+++ b/include/MCStack.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_MCMINI_MCSTATE_HPP
 #define INCLUDE_MCMINI_MCSTATE_HPP
 
+struct MCTransitionUniqueRep;
 struct MCTransition;
 struct MCSharedTransition;
 struct MCStack;
@@ -25,26 +26,6 @@ typedef MCTransition *(*MCSharedMemoryHandler)(
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-struct traceElement {
-  int tid;
-  std::string operation;
-
-  bool operator == (const traceElement &b) const {
-    return ((tid == b.tid) && (operation==b.operation));
-  }
-
-  bool operator != (const traceElement &b) const {
-     return ((tid != b.tid) || (operation != b.operation));
-   }
-
-  traceElement &operator = (const traceElement &b) {
-    tid = b.tid;
-    operation = b.operation;
-    return *this;
-  }
-};
-
 
 /**
  * @brief Set 'lastEnedOfTraceId = traceId'.
@@ -568,7 +549,7 @@ public:
 
   bool isInDeadlock() const;
   void increaseMaxTransitionsDepthLimit(int n);
-  bool hasRepetition(const traceElement* trace, int trace_len) const;
+  bool hasRepetition(const MCTransitionUniqueRep* trace, int trace_len) const;
   bool hasADataRaceWithNewTransition(const MCTransition &) const;
 
   inline bool
@@ -620,7 +601,7 @@ public:
 
   // TODO: De-couple priting from the state stack + transitions
   void printThreadSchedule() const;
-  void copyCurrentTraceToArray(traceElement* trace_arr, int& trace_len) const;
+  void copyCurrentTraceToArray(MCTransitionUniqueRep* trace_arr, int& trace_len) const;
   void printTransitionStack() const;
   void printNextTransitions() const;
   void printRepeatingTransitions(int pattern_len) const;

--- a/include/MCTransition.h
+++ b/include/MCTransition.h
@@ -1,6 +1,7 @@
 #ifndef MC_MCTRANSITION_H
 #define MC_MCTRANSITION_H
 
+#include <climits>
 #include "MCShared.h"
 #include "MCStack.h"
 #include "objects/MCThread.h"
@@ -8,6 +9,66 @@
 #include <utility>
 
 struct MCStack;
+
+enum MCTransitionType {
+  MC_NO_TRANSITION,
+  MC_COND_INIT,
+  MC_COND_WAIT,
+  MC_COND_BROADCAST,
+  MC_COND_SIGNAL,
+  MC_COND_ENQUEUE,
+  MC_THREAD_CREATE,
+  MC_THREAD_START,
+  MC_THREAD_JOIN,
+  MC_THREAD_FINISH,
+  MC_SEM_POST,
+  MC_SEM_WAIT,
+  MC_SEM_ENQUEUE,
+  MC_SEM_INIT,
+  MC_RW_LOCK_INIT,
+  MC_RW_LOCK_WRITER_LOCK,
+  MC_RW_LOCK_UNLOCK,
+  MC_RW_LOCK_WRITER_ENQUEUE,
+  MC_RW_LOCK_READER_LOCK,
+  MC_RW_LOCK_READER_ENQUEUE,
+  MC_MUTEX_UNLOCK,
+  MC_MUTEX_INIT,
+  MC_MUTEX_LOCK,
+  MC_BARRIER_WAIT,
+  MC_BARRIER_ENQUEUE,
+  MC_BARRIER_INIT,
+  MC_RWW_LOCK_WRITER_2_LOCK,
+  MC_RWW_LOCK_READER_LOCK,
+  MC_RWW_LOCK_UNLOCK,
+  MC_RWW_LOCK_WRITER_1_LOCK,
+  MC_RWW_LOCK_INIT,
+  MC_RWW_LOCK_WRITER_2_ENQUEUE,
+  MC_RWW_LOCK_READER_ENQUEUE,
+  MC_RWW_LOCK_WRITER_1_ENQUEUE,
+  MC_GLOBAL_VARIABLE_WRITE,
+  MC_GLOBAL_VARIABLE_READ,
+  MC_ABORT_TRANSITION,
+  MC_EXIT_TRANSITION
+};
+
+/* A structure used to store the unique representation
+ * of each transition
+ */
+struct MCTransitionUniqueRep {
+  enum MCTransitionType typeId;
+  int threadId;
+  union {
+    uint64_t val[2];
+    const void *addr[2];
+  } param;
+
+  static bool uniqueRepEqual (MCTransitionUniqueRep *a,
+                              MCTransitionUniqueRep *b) {
+    return (b->typeId == a->typeId &&
+            b->threadId == a->threadId &&
+            memcmp(&a->param, &b->param, sizeof(a->param)) == 0);
+  }
+};
 
 /**
  * A base class representing a fundamental unit in DPOR: the
@@ -524,6 +585,13 @@ public:
   {
     return this->thread->enabled();
   }
+
+  /**
+   * @brief returns a unique
+   * representation of transition
+   */
+  virtual MCTransitionUniqueRep
+  toUniqueRep() const = 0;
 
   // FIXME: De-couple printing from the interface
   virtual void

--- a/include/transitions/barrier/MCBarrierEnqueue.h
+++ b/include/transitions/barrier/MCBarrierEnqueue.h
@@ -24,6 +24,7 @@ public:
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/barrier/MCBarrierInit.h
+++ b/include/transitions/barrier/MCBarrierInit.h
@@ -20,6 +20,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/barrier/MCBarrierWait.h
+++ b/include/transitions/barrier/MCBarrierWait.h
@@ -21,6 +21,7 @@ public:
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool enabledInState(const MCStack *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/cond/MCCondBroadcast.h
+++ b/include/transitions/cond/MCCondBroadcast.h
@@ -20,6 +20,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/cond/MCCondEnqueue.h
+++ b/include/transitions/cond/MCCondEnqueue.h
@@ -27,6 +27,7 @@ public:
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/cond/MCCondInit.h
+++ b/include/transitions/cond/MCCondInit.h
@@ -20,6 +20,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/cond/MCCondSignal.h
+++ b/include/transitions/cond/MCCondSignal.h
@@ -20,6 +20,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/cond/MCCondWait.h
+++ b/include/transitions/cond/MCCondWait.h
@@ -24,6 +24,7 @@ public:
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool enabledInState(const MCStack *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/misc/MCAbortTransition.h
+++ b/include/transitions/misc/MCAbortTransition.h
@@ -24,6 +24,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool ensuresDeadlockIsImpossible() const override;
   bool countsAgainstThreadExecutionDepth() const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/misc/MCExitTransition.h
+++ b/include/transitions/misc/MCExitTransition.h
@@ -28,6 +28,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool ensuresDeadlockIsImpossible() const override;
   bool countsAgainstThreadExecutionDepth() const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/misc/MCGlobalVariableRead.h
+++ b/include/transitions/misc/MCGlobalVariableRead.h
@@ -23,6 +23,7 @@ public:
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool isRacingWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/misc/MCGlobalVariableWrite.h
+++ b/include/transitions/misc/MCGlobalVariableWrite.h
@@ -33,6 +33,7 @@ public:
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool isRacingWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/mutex/MCMutexInit.h
+++ b/include/transitions/mutex/MCMutexInit.h
@@ -22,6 +22,7 @@ public:
   bool isReversibleInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/mutex/MCMutexLock.h
+++ b/include/transitions/mutex/MCMutexLock.h
@@ -24,6 +24,7 @@ public:
   bool dependentWith(const MCTransition *) const override;
   bool enabledInState(const MCStack *) const override;
 
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/mutex/MCMutexUnlock.h
+++ b/include/transitions/mutex/MCMutexUnlock.h
@@ -22,6 +22,7 @@ public:
   bool isReversibleInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwlock/MCRWLockInit.h
+++ b/include/transitions/rwlock/MCRWLockInit.h
@@ -19,6 +19,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwlock/MCRWLockReaderEnqueue.h
+++ b/include/transitions/rwlock/MCRWLockReaderEnqueue.h
@@ -23,6 +23,7 @@ struct MCRWLockReaderEnqueue : public MCRWLockTransition {
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwlock/MCRWLockReaderLock.h
+++ b/include/transitions/rwlock/MCRWLockReaderLock.h
@@ -20,6 +20,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwlock/MCRWLockUnlock.h
+++ b/include/transitions/rwlock/MCRWLockUnlock.h
@@ -19,6 +19,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwlock/MCRWLockWriterEnqueue.h
+++ b/include/transitions/rwlock/MCRWLockWriterEnqueue.h
@@ -23,6 +23,7 @@ struct MCRWLockWriterEnqueue : public MCRWLockTransition {
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwlock/MCRWLockWriterLock.h
+++ b/include/transitions/rwlock/MCRWLockWriterLock.h
@@ -20,6 +20,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockInit.h
+++ b/include/transitions/rwwlock/MCRWWLockInit.h
@@ -19,6 +19,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockReaderEnqueue.h
+++ b/include/transitions/rwwlock/MCRWWLockReaderEnqueue.h
@@ -24,6 +24,7 @@ public:
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockReaderLock.h
+++ b/include/transitions/rwwlock/MCRWWLockReaderLock.h
@@ -20,6 +20,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockUnlock.h
+++ b/include/transitions/rwwlock/MCRWWLockUnlock.h
@@ -19,6 +19,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockWriter1Enqueue.h
+++ b/include/transitions/rwwlock/MCRWWLockWriter1Enqueue.h
@@ -24,6 +24,7 @@ public:
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockWriter1Lock.h
+++ b/include/transitions/rwwlock/MCRWWLockWriter1Lock.h
@@ -20,6 +20,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockWriter2Enqueue.h
+++ b/include/transitions/rwwlock/MCRWWLockWriter2Enqueue.h
@@ -24,6 +24,7 @@ public:
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/rwwlock/MCRWWLockWriter2Lock.h
+++ b/include/transitions/rwwlock/MCRWWLockWriter2Lock.h
@@ -20,6 +20,7 @@ public:
   bool enabledInState(const MCStack *) const override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/semaphore/MCSemEnqueue.h
+++ b/include/transitions/semaphore/MCSemEnqueue.h
@@ -25,6 +25,7 @@ public:
   {
     return false;
   }
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/semaphore/MCSemInit.h
+++ b/include/transitions/semaphore/MCSemInit.h
@@ -20,6 +20,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/semaphore/MCSemPost.h
+++ b/include/transitions/semaphore/MCSemPost.h
@@ -20,6 +20,7 @@ public:
   void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/semaphore/MCSemWait.h
+++ b/include/transitions/semaphore/MCSemWait.h
@@ -21,6 +21,7 @@ public:
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool enabledInState(const MCStack *) const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/threads/MCThreadCreate.h
+++ b/include/transitions/threads/MCThreadCreate.h
@@ -25,6 +25,7 @@ public:
   bool dependentWith(const MCTransition *) const override;
 
   bool doesCreateThread(tid_t) const;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/threads/MCThreadFinish.h
+++ b/include/transitions/threads/MCThreadFinish.h
@@ -26,6 +26,7 @@ public:
   bool dependentWith(const MCTransition *) const override;
   bool ensuresDeadlockIsImpossible() const override;
   bool countsAgainstThreadExecutionDepth() const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/threads/MCThreadJoin.h
+++ b/include/transitions/threads/MCThreadJoin.h
@@ -28,6 +28,7 @@ public:
   bool joinsOnThread(tid_t) const;
   bool joinsOnThread(const std::shared_ptr<MCThread> &) const;
 
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/include/transitions/threads/MCThreadStart.h
+++ b/include/transitions/threads/MCThreadStart.h
@@ -23,6 +23,7 @@ public:
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool countsAgainstThreadExecutionDepth() const override;
+  MCTransitionUniqueRep toUniqueRep() const override;
   void print() const override;
 };
 

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -313,7 +313,8 @@ isInLivelock()
 {
   const MCTransition *nextTransition = programState->getFirstEnabledTransition();
   bool hasLivelock = false;
-  traceElement traceArr[MC_STATE_CONFIG_MAX_TRANSITIONS_DEPTH_LIMIT_DEFAULT];
+  MCTransitionUniqueRep
+  traceArr[MC_STATE_CONFIG_MAX_TRANSITIONS_DEPTH_LIMIT_DEFAULT] = {};
   int traceLen = 0;
 
   while (nextTransition != nullptr && transitionId < MAX_TOTAL_TRANSITIONS_IN_PROGRAM) {

--- a/src/transitions/barrier/MCBarrierEnqueue.cpp
+++ b/src/transitions/barrier/MCBarrierEnqueue.cpp
@@ -69,6 +69,18 @@ MCBarrierEnqueue::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCBarrierEnqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_BARRIER_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->barrier->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCBarrierEnqueue::print() const
 {

--- a/src/transitions/barrier/MCBarrierInit.cpp
+++ b/src/transitions/barrier/MCBarrierInit.cpp
@@ -73,6 +73,18 @@ MCBarrierInit::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCBarrierInit::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_BARRIER_INIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->barrier->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = this->barrier->getCount();
+  return uniqueRep;
+}
+
 void
 MCBarrierInit::print() const
 {

--- a/src/transitions/barrier/MCBarrierWait.cpp
+++ b/src/transitions/barrier/MCBarrierWait.cpp
@@ -80,6 +80,18 @@ MCBarrierWait::enabledInState(const MCStack *state) const
   return !this->barrier->wouldBlockIfWaitedOn(this->getThreadId());
 }
 
+MCTransitionUniqueRep
+MCBarrierWait::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_BARRIER_WAIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->barrier->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCBarrierWait::print() const
 {

--- a/src/transitions/cond/MCCondBroadcast.cpp
+++ b/src/transitions/cond/MCCondBroadcast.cpp
@@ -149,6 +149,18 @@ MCCondBroadcast::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCCondBroadcast::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_COND_BROADCAST;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->conditionVariable->
+                                                       getObjectId());
+  uniqueRep.param.val[1] = !hadWaiters;
+  return uniqueRep;
+}
+
 void
 MCCondBroadcast::print() const
 {

--- a/src/transitions/cond/MCCondEnqueue.cpp
+++ b/src/transitions/cond/MCCondEnqueue.cpp
@@ -227,6 +227,18 @@ MCCondEnqueue::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCCondEnqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_COND_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->conditionVariable->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = countVisibleObjectsOfType(this->mutex->getObjectId());
+  return uniqueRep;
+}
+
 void
 MCCondEnqueue::print() const
 {

--- a/src/transitions/cond/MCCondInit.cpp
+++ b/src/transitions/cond/MCCondInit.cpp
@@ -156,6 +156,17 @@ MCCondInit::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCCondInit::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_COND_INIT; 
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->conditionVariable->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCCondInit::print() const
 {

--- a/src/transitions/cond/MCCondSignal.cpp
+++ b/src/transitions/cond/MCCondSignal.cpp
@@ -153,6 +153,18 @@ MCCondSignal::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCCondSignal::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_COND_SIGNAL;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->conditionVariable->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = !hadWaiters;
+  return uniqueRep;
+}
+
 void
 MCCondSignal::print() const
 {

--- a/src/transitions/cond/MCCondWait.cpp
+++ b/src/transitions/cond/MCCondWait.cpp
@@ -139,6 +139,19 @@ MCCondWait::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCCondWait::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_COND_WAIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->conditionVariable->
+                                                       getObjectId());
+  uniqueRep.param.val[1] = countVisibleObjectsOfType(this->conditionVariable->
+                                                       mutex->getObjectId());
+  return uniqueRep;
+}
+
 void
 MCCondWait::print() const
 {

--- a/src/transitions/misc/MCAbortTransition.cpp
+++ b/src/transitions/misc/MCAbortTransition.cpp
@@ -44,6 +44,17 @@ MCAbortTransition::enabledInState(const MCStack *) const
   return true;
 }
 
+MCTransitionUniqueRep
+MCAbortTransition::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_ABORT_TRANSITION;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = UINT_MAX;
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCAbortTransition::print() const
 {

--- a/src/transitions/misc/MCExitTransition.cpp
+++ b/src/transitions/misc/MCExitTransition.cpp
@@ -42,6 +42,17 @@ MCExitTransition::enabledInState(const MCStack *) const
   return false; // Never enabled
 }
 
+MCTransitionUniqueRep
+MCExitTransition::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_EXIT_TRANSITION;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = UINT_MAX;
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCExitTransition::print() const
 {

--- a/src/transitions/misc/MCGlobalVariableRead.cpp
+++ b/src/transitions/misc/MCGlobalVariableRead.cpp
@@ -75,6 +75,17 @@ MCGlobalVariableRead::isRacingWith(
   return false;
 }
 
+MCTransitionUniqueRep
+MCGlobalVariableRead::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_GLOBAL_VARIABLE_READ;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.addr[0] = this->global->addr;
+  uniqueRep.param.addr[1] = NULL;
+  return uniqueRep;
+}
+
 void
 MCGlobalVariableRead::print() const
 {

--- a/src/transitions/misc/MCGlobalVariableWrite.cpp
+++ b/src/transitions/misc/MCGlobalVariableWrite.cpp
@@ -82,6 +82,17 @@ MCGlobalVariableWrite::isRacingWith(
   return false;
 }
 
+MCTransitionUniqueRep
+MCGlobalVariableWrite::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_GLOBAL_VARIABLE_WRITE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.addr[0] = this->global->addr;
+  uniqueRep.param.addr[1] = this->newValue;
+  return uniqueRep;
+}
+
 void
 MCGlobalVariableWrite::print() const
 {

--- a/src/transitions/mutex/MCMutexInit.cpp
+++ b/src/transitions/mutex/MCMutexInit.cpp
@@ -84,6 +84,17 @@ MCMutexInit::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCMutexInit::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_MUTEX_INIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->mutex->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCMutexInit::print() const
 {

--- a/src/transitions/mutex/MCMutexLock.cpp
+++ b/src/transitions/mutex/MCMutexLock.cpp
@@ -173,6 +173,17 @@ MCMutexLock::dependentWith(const MCTransition *transition) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCMutexLock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_MUTEX_LOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->mutex->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCMutexLock::print() const
 {

--- a/src/transitions/mutex/MCMutexUnlock.cpp
+++ b/src/transitions/mutex/MCMutexUnlock.cpp
@@ -87,6 +87,17 @@ MCMutexUnlock::dependentWith(const MCTransition *transition) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCMutexUnlock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_MUTEX_UNLOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->mutex->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCMutexUnlock::print() const
 {

--- a/src/transitions/rwlock/MCRWLockInit.cpp
+++ b/src/transitions/rwlock/MCRWLockInit.cpp
@@ -70,6 +70,18 @@ MCRWLockInit::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWLockInit::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RW_LOCK_INIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWLockInit::print() const
 {

--- a/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderEnqueue.cpp
@@ -73,6 +73,17 @@ MCRWLockReaderEnqueue::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWLockReaderEnqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RW_LOCK_READER_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwlock->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWLockReaderEnqueue::print() const
 {

--- a/src/transitions/rwlock/MCRWLockReaderLock.cpp
+++ b/src/transitions/rwlock/MCRWLockReaderLock.cpp
@@ -152,6 +152,17 @@ MCRWLockReaderLock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWLockReaderLock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RW_LOCK_READER_LOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwlock->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWLockReaderLock::print() const
 {

--- a/src/transitions/rwlock/MCRWLockUnlock.cpp
+++ b/src/transitions/rwlock/MCRWLockUnlock.cpp
@@ -72,6 +72,17 @@ MCRWLockUnlock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWLockUnlock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RW_LOCK_UNLOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwlock->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWLockUnlock::print() const
 {

--- a/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterEnqueue.cpp
@@ -73,6 +73,17 @@ MCRWLockWriterEnqueue::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWLockWriterEnqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RW_LOCK_WRITER_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwlock->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWLockWriterEnqueue::print() const
 {

--- a/src/transitions/rwlock/MCRWLockWriterLock.cpp
+++ b/src/transitions/rwlock/MCRWLockWriterLock.cpp
@@ -148,6 +148,18 @@ MCRWLockWriterLock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWLockWriterLock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RW_LOCK_WRITER_LOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWLockWriterLock::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockInit.cpp
+++ b/src/transitions/rwwlock/MCRWWLockInit.cpp
@@ -68,6 +68,18 @@ MCRWWLockInit::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockInit::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_INIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockInit::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderEnqueue.cpp
@@ -73,6 +73,18 @@ MCRWWLockReaderEnqueue::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockReaderEnqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_READER_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockReaderEnqueue::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockReaderLock.cpp
@@ -103,6 +103,18 @@ MCRWWLockReaderLock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockReaderLock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_READER_LOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId()); 
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockReaderLock::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockUnlock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockUnlock.cpp
@@ -72,6 +72,18 @@ MCRWWLockUnlock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockUnlock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_UNLOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockUnlock::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Enqueue.cpp
@@ -76,6 +76,18 @@ MCRWWLockWriter1Enqueue::dependentWith(
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockWriter1Enqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_WRITER_1_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockWriter1Enqueue::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter1Lock.cpp
@@ -98,6 +98,18 @@ MCRWWLockWriter1Lock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockWriter1Lock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_WRITER_1_LOCK; 
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId()); 
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockWriter1Lock::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Enqueue.cpp
@@ -76,6 +76,18 @@ MCRWWLockWriter2Enqueue::dependentWith(
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockWriter2Enqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_WRITER_2_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockWriter2Enqueue::print() const
 {

--- a/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
+++ b/src/transitions/rwwlock/MCRWWLockWriter2Lock.cpp
@@ -98,6 +98,18 @@ MCRWWLockWriter2Lock::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCRWWLockWriter2Lock::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_RWW_LOCK_WRITER_2_LOCK;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->rwwlock->
+                                                        getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCRWWLockWriter2Lock::print() const
 {

--- a/src/transitions/semaphore/MCSemEnqueue.cpp
+++ b/src/transitions/semaphore/MCSemEnqueue.cpp
@@ -88,6 +88,17 @@ MCSemEnqueue::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCSemEnqueue::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_SEM_ENQUEUE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->sem->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCSemEnqueue::print() const
 {

--- a/src/transitions/semaphore/MCSemInit.cpp
+++ b/src/transitions/semaphore/MCSemInit.cpp
@@ -67,6 +67,17 @@ MCSemInit::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCSemInit::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_SEM_INIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->sem->getObjectId());
+  uniqueRep.param.val[1] = this->sem->getCount();
+  return uniqueRep;
+}
+
 void
 MCSemInit::print() const
 {

--- a/src/transitions/semaphore/MCSemPost.cpp
+++ b/src/transitions/semaphore/MCSemPost.cpp
@@ -72,6 +72,17 @@ MCSemPost::dependentWith(const MCTransition *other) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCSemPost::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_SEM_POST;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->sem->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCSemPost::print() const
 {

--- a/src/transitions/semaphore/MCSemWait.cpp
+++ b/src/transitions/semaphore/MCSemWait.cpp
@@ -86,6 +86,17 @@ MCSemWait::enabledInState(const MCStack *) const
   return this->sem->threadCanExit(this->getThreadId());
 }
 
+MCTransitionUniqueRep
+MCSemWait::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_SEM_WAIT;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = countVisibleObjectsOfType(this->sem->getObjectId());
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCSemWait::print() const
 {

--- a/src/transitions/threads/MCThreadCreate.cpp
+++ b/src/transitions/threads/MCThreadCreate.cpp
@@ -93,6 +93,17 @@ MCThreadCreate::doesCreateThread(tid_t tid) const
   return this->target->tid == tid;
 }
 
+MCTransitionUniqueRep
+MCThreadCreate::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_THREAD_CREATE;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = this->target->tid;
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCThreadCreate::print() const
 {

--- a/src/transitions/threads/MCThreadFinish.cpp
+++ b/src/transitions/threads/MCThreadFinish.cpp
@@ -73,6 +73,17 @@ MCThreadFinish::dependentWith(const MCTransition *transition) const
   return false;
 }
 
+MCTransitionUniqueRep
+MCThreadFinish::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_THREAD_FINISH;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = UINT_MAX;
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCThreadFinish::print() const
 {

--- a/src/transitions/threads/MCThreadJoin.cpp
+++ b/src/transitions/threads/MCThreadJoin.cpp
@@ -113,6 +113,17 @@ MCThreadJoin::joinsOnThread(
   return this->target->tid == thread->tid;
 }
 
+MCTransitionUniqueRep
+MCThreadJoin::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_THREAD_JOIN;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = this->target->tid;
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCThreadJoin::print() const
 {

--- a/src/transitions/threads/MCThreadStart.cpp
+++ b/src/transitions/threads/MCThreadStart.cpp
@@ -65,6 +65,17 @@ MCThreadStart::dependentWith(const MCTransition *transition) const
   return this->thread->tid == transition->getThreadId();
 }
 
+MCTransitionUniqueRep
+MCThreadStart::toUniqueRep() const
+{
+  MCTransitionUniqueRep uniqueRep;
+  uniqueRep.typeId = MC_THREAD_START;
+  uniqueRep.threadId = this->thread->tid;
+  uniqueRep.param.val[0] = UINT_MAX;
+  uniqueRep.param.val[1] = UINT_MAX;
+  return uniqueRep;
+}
+
 void
 MCThreadStart::print() const
 {


### PR DESCRIPTION
Replaced the old traceElement struct, which relied on just the threadId and typeId with a new struct, MCTransitionUniqueRep.