### PR TITLE
LLVM plugin for data race detection

### DIFF
--- a/Makefile_llvm
+++ b/Makefile_llvm
@@ -1,3 +1,12 @@
+# For McMini to check data races concerning shared variables, the target
+# program must be specially compiled to use LLVM.
+# On most Linux distros, LLVM can be installed by adding the following packages:
+#   llvm llvm-dev clang
+# On Red Hat-based distros, use llvm-devel
+#
+# To compile the target_file with LLVM, run:
+#   make -f Makefile_llvm TEST="path/to/target_file"
+
 CLANG := clang
 CLANGXX := clang++
 OPT := opt
@@ -7,11 +16,11 @@ PASS_SRC := src/InstrumentMcMiniGlobals.cpp
 PASS_SO := InstrumentMcMiniGlobalsPass.so
 LIBOBJS := libmcmini.so
 
-TESTS ?= test/data_race
+TEST ?= test/data_race
 
 .PHONY: all clean
 
-all: $(PASS_SO) $(addsuffix _instr, $(TESTS))
+all: $(PASS_SO) $(addsuffix _instr, $(TEST))
 
 # Build the LLVM instrumentation pass shared library
 $(PASS_SO): $(PASS_SRC)

--- a/Makefile_llvm
+++ b/Makefile_llvm
@@ -1,0 +1,47 @@
+CLANG := clang
+CLANGXX := clang++
+OPT := opt
+LLVM_CONFIG := llvm-config
+
+PASS_SRC := src/InstrumentMcMiniGlobals.cpp
+PASS_SO := InstrumentMcMiniGlobalsPass.so
+LIBOBJS := libmcmini.so
+
+TESTS ?= test/data_race
+
+.PHONY: all clean
+
+all: $(PASS_SO) $(addsuffix _instr, $(TESTS))
+
+# Build the LLVM instrumentation pass shared library
+$(PASS_SO): $(PASS_SRC)
+	$(CXX) -g3 -O0 -Iinclude -fPIC \
+	`$(LLVM_CONFIG) --cxxflags` \
+	-shared -o $@ $< \
+	`$(LLVM_CONFIG) --ldflags` \
+        `$(LLVM_CONFIG) --libs core irreader passes analysis transformutils support` \
+	`$(LLVM_CONFIG) --system-libs` \
+	-I`$(LLVM_CONFIG) --includedir`
+
+# Compile .c to LLVM IR (Intermediate Representation)
+# *.ll is human readable, compiled with -S flag
+# *.bc is "bit code", without the -S flag
+%.ll: %.c
+	$(CLANG) -O0 -g -emit-llvm -c -S $< -o $@
+
+# Instrument bitcode using the LLVM pass
+%_instr.ll: %.ll $(PASS_SO)
+	$(OPT) -load-pass-plugin=`pwd`/$(PASS_SO) \
+	       -passes=instrument-mcmini-globals -S $< -o $@
+
+# Link instrumented bitcode to executable
+%_instr: %_instr.ll
+	$(CLANGXX) $< $(LIBOBJS) -Iinclude -o $@ -lpthread -lrt -lm -ldl
+
+# Build uninstrumented executable directly from source
+%_uninstr: %.c
+	$(CLANG) -O0 -g $< -o $@ -lpthread -lrt -lm -ldl
+
+clean:
+	rm -f *.ll *_instr.ll *_instr *_uninstr $(PASS_SO)
+

--- a/src/InstrumentMcMiniGlobals.cpp
+++ b/src/InstrumentMcMiniGlobals.cpp
@@ -1,0 +1,104 @@
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/GlobalsModRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llvm/Config/llvm-config.h" // For LLVM_VERSION_MAJOR macro detection
+
+using namespace llvm;
+
+namespace {
+class InstrumentMcMiniGlobalsPass : public PassInfoMixin<InstrumentMcMiniGlobalsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM) {
+    LLVMContext &Ctx = M.getContext();
+
+#if LLVM_VERSION_MAJOR >= 15
+    Type *PtrTy = PointerType::get(Ctx, 0);
+#else
+    Type *PtrTy = Type::getInt8PtrTy(Ctx);
+#endif
+
+    FunctionCallee checkReadFn = M.getOrInsertFunction(
+        "mcmini_read", PtrTy, PtrTy);
+
+    FunctionCallee checkWriteFn = M.getOrInsertFunction(
+        "mcmini_write", Type::getVoidTy(Ctx), PtrTy, PtrTy);
+
+    bool Changed = false;
+    SmallVector<GlobalVariable *, 16> Globals;
+    for (GlobalVariable &GV : M.globals())
+      Globals.push_back(&GV);
+
+    auto &FAMProxy = MAM.getResult<FunctionAnalysisManagerModuleProxy>(M);
+    FunctionAnalysisManager &FAM = FAMProxy.getManager();
+
+    for (Function &F : M) {
+      if (F.isDeclaration())
+        continue;
+
+      AliasAnalysis &AA = FAM.getResult<AAManager>(F);
+      for (Instruction &I : instructions(F)) {
+        IRBuilder<> Builder(&I);
+        if (auto *LI = dyn_cast<LoadInst>(&I)) {
+          Value *Ptr = LI->getPointerOperand();
+          GlobalVariable *GlobalFound = findAliasedGlobal(Ptr, Globals, AA);
+          if (GlobalFound) {
+            Builder.SetInsertPoint(LI);
+            Value *ptrCast = Builder.CreateBitCast(Ptr, PtrTy);
+            Builder.CreateCall(checkReadFn, {ptrCast});
+            Changed = true;
+          }
+        } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+          Value *Ptr = SI->getPointerOperand();
+          GlobalVariable *GlobalFound = findAliasedGlobal(Ptr, Globals, AA);
+          if (GlobalFound) {
+            Builder.SetInsertPoint(SI);
+            Constant *varNameConst = Builder.CreateGlobalStringPtr(GlobalFound->getName());
+            Value *ptrCast = Builder.CreateBitCast(Ptr, PtrTy);
+            Builder.CreateCall(checkWriteFn, {varNameConst, ptrCast});
+            Changed = true;
+          }
+        }
+      }
+    }
+    return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
+private:
+  GlobalVariable *findAliasedGlobal(Value *Ptr, ArrayRef<GlobalVariable *> Globals, AliasAnalysis &AA) {
+    for (GlobalVariable *GV : Globals) {
+      AliasResult AR = AA.alias(Ptr, GV);
+      if (AR != AliasResult::NoAlias) {
+        return GV;
+      }
+    }
+    return nullptr;
+  }
+};
+} // namespace
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "InstrumentMcMiniGlobalsPass", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM, ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == "instrument-mcmini-globals") {
+                    MPM.addPass(InstrumentMcMiniGlobalsPass());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+

--- a/src/launch.c
+++ b/src/launch.c
@@ -152,6 +152,8 @@ main(int argc, char *argv[])
                       "              target_executable\n"
                       "       mcmini-gdb ...<same as mcmini args>...\n"
                       "       python3 mcmini-annotate.py -t <traceSeq> ...<same as mcmini args>...\n",
+                      "       (To check data races in target, compile target as in\n", 
+                      "        Makefile_llvm in the top level of the McMini source code.)\n",
               MC_STATE_CONFIG_MAX_TRANSITIONS_DEPTH_LIMIT_DEFAULT
              );
       exit(1);

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -669,6 +669,12 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
         programState->printTransitionStack();
         programState->printNextTransitions();
         addResult("*** DATA RACE DETECTED ***\n");
+
+        if (getenv(ENV_FIRST_DEADLOCK)) {
+          traceId++;
+          printResults();
+          mc_exit(EXIT_SUCCESS);
+        }
       }
     }
 

--- a/test/data_race.c
+++ b/test/data_race.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <pthread.h>
+
+int counter = 0;
+
+void* increment(void* arg) {
+    for (int i = 0; i < 1000000; i++) {
+        counter++;  // Data race happens here
+    }
+    return NULL;
+}
+
+int main() {
+    pthread_t t1, t2;
+
+    pthread_create(&t1, NULL, increment, NULL);
+    pthread_create(&t2, NULL, increment, NULL);
+
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    printf("Final counter value: %d\n", counter);
+    return 0;
+}
+


### PR DESCRIPTION
The instrumentation pass plugin has been tested
on LLVM 14 and LLVM 18.

Quick test:
```
make -f Makefile_llvm
./mcmini -m5 ./test/data_race_instr
```