### PR TITLE
Fix correctness issues in livelock detection and round-robin scheduling

### DIFF
--- a/include/MCStack.h
+++ b/include/MCStack.h
@@ -565,6 +565,10 @@ public:
                        const std::unordered_set<tid_t> &enabled,
                        std::vector<stateLlock> &visitedStates);
 #endif
+  bool canStopSafely(const std::unordered_set<tid_t> &related,
+                     const std::unordered_set<tid_t> &explored,
+                     const std::unordered_set<tid_t> &enabled,
+                     int cycleStartIdx);
   void increaseMaxTransitionsDepthLimit(int);
   void resetMaxTransitionsDepthLimit();
   bool hasADataRaceWithNewTransition(const MCTransition &) const;

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -402,7 +402,9 @@ const MCTransition *MCStack::getNextFairTransition(tid_t tid) {
     MCTransition &nextTransition =
       programState->getNextTransitionForThread(tid);
 
-    if (programState->transitionIsEnabled(nextTransition)) {
+    const MCStackItem &sTop = getStateStackTop();
+    const bool transitionIsInSleepSet = sTop.threadIsInSleepSet(i);
+    if (programState->transitionIsEnabled(nextTransition) && !transitionIsInSleepSet) {
       return &nextTransition;
     }
   }

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -475,7 +475,7 @@ MCStack::isInDeadlock() const
   return true;
 }
 
-bool transitionsAreRelated(MCTransition* a, MCTransition *b)
+bool transitionsAreCausallyRelated(MCTransition* a, MCTransition *b)
 {
   unordered_set<objid_t> objsA = a->getObjectsAccessedByTransition();
   unordered_set<objid_t> objsB = b->getObjectsAccessedByTransition();
@@ -613,6 +613,9 @@ MCStack::isInLivelock(int increasedDepth)
 #ifdef LIVELOCK_EARLY_STOPPING
     visitedStates.clear();
 #endif
+    if (nextTransition->toUniqueRep().typeId == MC_PROGRESS_TRANSITION) {
+      return false;
+    }
     mc_run_thread_to_next_visible_operation(start_tid);
     this->simulateRunningTransition(
       *nextTransition, shmTransitionTypeInfo, shmTransitionData);
@@ -633,8 +636,11 @@ MCStack::isInLivelock(int increasedDepth)
 
       for (int tid = 0; tid < numThreads; tid++) {
         if (threadIsRelated.count(tid) == 0 &&
-         //   threadIsExplored.count(tid) == 0 &&
-            transitionsAreRelated(&getNextTransitionForThread(tid),
+            // For example, if a semaphore has count 1, and one thread calls
+            // sem_post() on that semaphore, then a second thread that may
+            // call sem_wait() multiple times in the future is said to be
+            // causally related with the first thread.
+            transitionsAreCausallyRelated(&getNextTransitionForThread(tid),
                                   &this->getTransitionStackTop())) {
           threadIsRelated.insert(tid);
         }
@@ -651,9 +657,18 @@ MCStack::isInLivelock(int increasedDepth)
       }
 
       nextTransition = &(this->getNextTransitionForThread(next_tid));
+
+      // There may exist a case where the current cycle cannot continue
+      // to execute, since the relatedThreads set is empty, and the next
+      // transition of the seed thread is blocked. In that case, we terminate
+      // the current cycle and continue to the next.
+      if (!this->transitionIsEnabled(*nextTransition)) {
+        continue;
+      }
       if ((nextTransition->toUniqueRep()).typeId == MC_PROGRESS_TRANSITION) {
         return false;
       }
+
       mc_run_thread_to_next_visible_operation(next_tid);
       this->simulateRunningTransition(
         *nextTransition, shmTransitionTypeInfo, shmTransitionData);
@@ -683,11 +698,8 @@ MCStack::isInLivelock(int increasedDepth)
 
     if (n == numThreads) start_tid = -1;
   }
-  if (hasLivelock) {
-    this->printLivelockResults(livelockStartIdx, cycleStartIdx, numCycles);
-  }
-  this->resetMaxTransitionsDepthLimit();
-  return hasLivelock;
+  this->printLivelockResults(livelockStartIdx, cycleStartIdx, numCycles);
+  return true;
 }
 
 // increaseMaxTransitionsDepthLimit() and resetMaxTransitionsDepthLimit() used

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -546,26 +546,49 @@ MCStack::stateIsRevisited(MCObjectStore &store,
   return false;
 }
 
-bool canStopSafely(const std::unordered_set<tid_t> &related,
-                   const std::unordered_set<tid_t> &explored,
-                   const std::unordered_set<tid_t> &enabled)
+bool
+MCStack::canStopSafely(const std::unordered_set<tid_t> &related,
+                       const std::unordered_set<tid_t> &explored,
+                       const std::unordered_set<tid_t> &enabled,
+                       int cycleStartIdx)
 {
-  bool unexploredExists = false;
+  int top = this->transitionStackTop;
 
   for (tid_t tid : related) {
-    bool isExplored = explored.count(tid);
-    bool isEnabled = enabled.count(tid);
 
-    if (!isExplored) {
-      unexploredExists = true;
+    // Skip threads that don't need checking
+    if (explored.count(tid) || enabled.count(tid)) {
+      continue;
+    }
 
-      if (isEnabled) {
-        return true;
+    // Blocked thread case
+    MCTransition &nextTransition =
+        this->getNextTransitionForThread(tid);
+
+    const std::unordered_set<objid_t> &nextTransitionObjs =
+        nextTransition.getObjectsAccessedByTransition();
+
+    // Scan only current cycle
+    for (int i = top; i >= cycleStartIdx; i--) {
+
+      MCTransition &cycleTransition =
+          this->getTransitionAtIndex(i);
+
+      const std::unordered_set<objid_t> &cycleObjects =
+          cycleTransition.getObjectsAccessedByTransition();
+
+      for (objid_t obj : nextTransitionObjs) {
+        if (cycleObjects.count(obj)) {
+          // Blocking depends on cycle → not safe to stop
+          return false;
+        }
       }
     }
   }
-  return !unexploredExists;
+
+  return true;
 }
+
 #endif
 
 void
@@ -681,7 +704,7 @@ MCStack::isInLivelock(int increasedDepth)
                              this->getCurrentlyEnabledThreads(), visitedStates);
 
       if (stateRevisited && canStopSafely(threadIsRelated, threadIsExplored,
-                                          this->getCurrentlyEnabledThreads())) {
+                                          this->getCurrentlyEnabledThreads(), cycleStart)) {
         break;
       }
 #endif

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -667,6 +667,7 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
         }
         programState->increaseMaxTransitionsDepthLimit(increasedDepth);
         hasLivelock = programState->isInLivelock(increasedDepth);
+        programState->resetMaxTransitionsDepthLimit();
         /*
          * isInLivelock() exits before reaching
          * LLOCK_INCREASED_MAX_TRANSITIONS_DEPTH
@@ -810,9 +811,17 @@ get_config_for_execution_environment()
   uint64_t maxThreadDepth = MC_STATE_CONFIG_MAX_DEPTH_PER_THREAD_DEFAULT;
   uint64_t maxTotalDepth =
                        MC_STATE_CONFIG_MAX_TRANSITIONS_DEPTH_LIMIT_DEFAULT - 1;
-  
+
+
+  // The default value of maxTotalDepth needs to be lower when checking for
+  // livelock, since the livelock detection algorithm extends a branch beyond
+  // this limit. If the default were to be set to the maximum size of the stack
+  // in this case, then it would result in a segfault.
+  // The lower default value is calculated for the worst case, which is when
+  // a program consists of threads equal to the maximum allowed number and
+  // every thread decomposes into an individual cycle.
   if (getenv(ENV_CHECK_FOR_LIVELOCK)) {
-    maxTotalDepth -= LLOCK_INCREASED_MAX_TRANSITIONS_DEPTH;
+    maxTotalDepth -= (MAX_TOTAL_THREADS_IN_PROGRAM * LLOCK_INCREASED_MAX_TRANSITIONS_DEPTH);
   }  
 
   trid_t printBacktraceAtTraceNumber = MC_STATE_CONFIG_PRINT_AT_TRACE;


### PR DESCRIPTION
This PR fixes several correctness issues in the livelock detection implementation and improves the safety of suffix exploration.

The changes are briefly described as follows:

1. A stronger canStopSafely check
2. Use sleep sets for the round-robin scheduling function
3. Fix segfault caused due to incorrect adjustment of max-total-transitions default value for livelock detection
4. Add check for progress for the first transition in suffix
5. Add one missing check for enabledness of transition before execution