### PR TITLE
BUG FIX: Premature waiter removal in condvar

### DIFF
--- a/src/misc/cond/MCConditionVariableSingleGroupPolicy.cpp
+++ b/src/misc/cond/MCConditionVariableSingleGroupPolicy.cpp
@@ -14,7 +14,7 @@ ConditionVariableSingleGroupPolicy::receive_broadcast_message()
   for (const tid_t waiting_thread : this->wait_queue) {
     this->broadcast_eligible_threads.insert(waiting_thread);
   }
-  this->wait_queue.clear();
+  this->wake_groups.clear();
 }
 
 void


### PR DESCRIPTION
Previously, `conditionVariableSingleGroupPolicy::receive_broadcast_message()` cleared the wait_queue immediately after marking threads as broadcast eligible.

This caused convar waiters to disappear before `cond_wait` had actually completed, i.e. before the waiting thread re-acquired the mutex and returned from the wait. As a result, `has_waiters()` returned false incorrectly, leading to premature cleanup of condvar state.

Waiters are now removed only during wake completion in `MCCondWait::applyToState()`, making broadcast behavior consistent with signal semantics. The broadcast now clears `wake_groups` instead of clearing the `wait_queue`.