### PR TITLE
Add global variable value tracking and livelock detection timing

### DIFF
--- a/include/objects/MCGlobalVariable.h
+++ b/include/objects/MCGlobalVariable.h
@@ -5,25 +5,29 @@
 
 struct MCGlobalVariable : public MCVisibleObject {
 private:
-  inline explicit MCGlobalVariable(void *addr, char *varName, objid_t id)
-    : MCVisibleObject(id), addr(addr), varName(varName)
+  inline explicit MCGlobalVariable(void *addr, char *varName, objid_t id,
+                                   uint64_t val)
+    : MCVisibleObject(id), addr(addr), varName(varName), val(val)
   {
   }
 
 public:
   void *const addr;
   char *varName;
-  explicit MCGlobalVariable(void *addr, char *varName) : 
-    addr(addr), varName(varName) {}
+  uint64_t val;
+
+  explicit MCGlobalVariable(void *addr, char *varName, uint64_t val = 0)
+    : addr(addr), varName(varName), val(val) {}
 
   MCGlobalVariable(const MCGlobalVariable &global)
-    : MCGlobalVariable(global.addr, global.varName, global.getObjectId())
+    : MCGlobalVariable(global.addr, global.varName,
+                       global.getObjectId(), global.val)
   {
   }
 
   std::shared_ptr<MCVisibleObject> copy() override;
   MCSystemID getSystemId() override;
-  // bool MCObjectEquals(const MCVisibleObject &other) const override;
+  bool MCObjectEquals(const MCVisibleObject &other) const override;
 
   bool operator==(const MCGlobalVariable &) const;
   bool operator!=(const MCGlobalVariable &) const;

--- a/include/transitions/misc/MCGlobalVariableWrite.h
+++ b/include/transitions/misc/MCGlobalVariableWrite.h
@@ -9,26 +9,29 @@ MCTransition *MCReadGlobalWrite(const MCSharedTransition *, void *,
 struct MCGlobalVariableWriteData {
   void *addr;
   char *varName;
+  uint64_t value;
 
-  MCGlobalVariableWriteData(void *addr, char *varName)
-    : addr(addr), varName(varName)
+  MCGlobalVariableWriteData(void *addr, char *varName, uint64_t value)
+    : addr(addr), varName(varName), value(value)
   {
   }
 };
 
 struct MCGlobalVariableWrite : public MCGlobalVariableTransition {
 public:
-  const void *newValue;
+  uint64_t writeValue;
   MCGlobalVariableWrite(std::shared_ptr<MCThread> running,
-                        std::shared_ptr<MCGlobalVariable> global)
-    : MCGlobalVariableTransition(running, global)
+                        std::shared_ptr<MCGlobalVariable> global,
+                        uint64_t writeValue = 0)
+    : MCGlobalVariableTransition(running, global),
+      writeValue(writeValue)
   {
   }
 
   std::shared_ptr<MCTransition> staticCopy() const override;
   std::shared_ptr<MCTransition>
   dynamicCopyInState(const MCStack *) const override;
-  void applyToState(MCStack *) override {}
+  void applyToState(MCStack *) override;
   bool coenabledWith(const MCTransition *) const override;
   bool dependentWith(const MCTransition *) const override;
   bool isRacingWith(const MCTransition *) const override;

--- a/include/transitions/wrappers/MCGlobalVariableWrappers.h
+++ b/include/transitions/wrappers/MCGlobalVariableWrappers.h
@@ -4,9 +4,9 @@
 #include "MCShared.h"
 
 MC_EXTERN void *mcmini_read(void *, char *);
-MC_EXTERN void mcmini_write(void *, char *);
+MC_EXTERN void mcmini_write(void *, char *, uint64_t value);
 
-#define MC_TRACK_READ(x)         mcmini_read(x)
-#define MC_TRACK_WRITE(x, x_new) mcmini_write(x, x_new)
+#define MC_TRACK_READ(x)         mcmini_read(&(x), #x)
+#define MC_TRACK_WRITE(x, x_new) mcmini_write(&(x), #x, (uint64_t)(x_new))
 
 #endif // MC_MCGLOBALVARIABLEWRAPPERS_H

--- a/src/MCStack.cpp
+++ b/src/MCStack.cpp
@@ -531,7 +531,7 @@ MCStack::stateIsRevisited(MCObjectStore &store,
     }
 
     bool objectsEqual = true;
-    for (size_t i = 0; i < store.getStorageTop(); i++) {
+    for (size_t i = 0; i <= store.getStorageTop(); i++) {
       if (!oldState.objects[i]->MCObjectEquals(
             *current.objects[i])) {
         objectsEqual = false;

--- a/src/mcmini_private.cpp
+++ b/src/mcmini_private.cpp
@@ -8,6 +8,7 @@
 #include <errno.h>    // For errno
 #include <cstring>    // For strerror
 #include <iostream>   // For std::cerr
+#include <chrono>     // For high-resolution timing
 
 extern "C" {
 #include "mc_shared_sem.h"
@@ -33,6 +34,8 @@ trid_t traceId      = 0;
 trid_t transitionId = 0;
 
 time_t mcmini_start_time = 0;
+chrono::steady_clock::time_point mcmini_start_hires;
+uint64_t total_livelock_elapsed_ns = 0;
 volatile bool mc_reset = false;
 
 /**
@@ -67,7 +70,13 @@ static void printResults() {
   mcprintf(resultString);
   mcprintf("Number of traces: %lu\n", traceId);
   mcprintf("Total number of transitions: %lu\n", transitionId);
-  mcprintf("Elapsed time: %lu seconds\n", time(NULL) - mcmini_start_time);
+  auto elapsed_ms = chrono::duration_cast<chrono::milliseconds>(
+    chrono::steady_clock::now() - mcmini_start_hires).count();
+  mcprintf("Elapsed time: %lu ms\n", (unsigned long)elapsed_ms);
+  if (total_livelock_elapsed_ns > 0) {
+    mcprintf("Livelock detection overhead: %lu ms\n",
+             (unsigned long)(total_livelock_elapsed_ns / 1000000));
+  }
   if ((int)traceId < programState->traceIdForPrintBacktrace() &&
       getenv(ENV_FIRST_DEADLOCK) == NULL) { // and no --first-deadlock
     mcprintf("*** NOTE: --trace (-t) requested up to trace %d,\n"
@@ -125,6 +134,7 @@ MC_CONSTRUCTOR void
 mcmini_main()
 {
   mcmini_start_time = time(NULL);
+  mcmini_start_hires = chrono::steady_clock::now();
 
   getcontext(&mcmini_scheduler_main_context);
 
@@ -297,7 +307,7 @@ mc_explore_branch(int curBranchPoint)
   }
   resetTraceSeqArray();
 
-  static time_t last_time_reported = mcmini_start_time;
+  static time_t last_time_reported = time(NULL);
   static int interval = 1000;
   if (traceId == 100 && time(NULL) - last_time_reported > 10) {
     interval = 100;
@@ -679,7 +689,11 @@ mc_search_dpor_branch_with_thread(const tid_t backtrackThread)
             strtoul(getenv(ENV_MAX_LIVELOCK_CYCLE_LIMIT), nullptr, 10);
         }
         programState->increaseMaxTransitionsDepthLimit(increasedDepth);
+        auto livelock_start = chrono::steady_clock::now();
         hasLivelock = programState->isInLivelock(increasedDepth, transitionId);
+        total_livelock_elapsed_ns +=
+          chrono::duration_cast<chrono::nanoseconds>(
+            chrono::steady_clock::now() - livelock_start).count();
         programState->resetMaxTransitionsDepthLimit();
         /*
          * isInLivelock() exits before reaching

--- a/src/objects/MCGlobalVariable.cpp
+++ b/src/objects/MCGlobalVariable.cpp
@@ -12,6 +12,17 @@ MCGlobalVariable::operator!=(const MCGlobalVariable &other) const
   return this->addr != other.addr;
 }
 
+bool
+MCGlobalVariable::MCObjectEquals(const MCVisibleObject &other) const
+{
+  const MCGlobalVariable *otherVar =
+    dynamic_cast<const MCGlobalVariable *>(&other);
+  if (!otherVar) {
+    return false;
+  }
+  return this->addr == otherVar->addr && this->val == otherVar->val;
+}
+
 MCSystemID
 MCGlobalVariable::getSystemId()
 {

--- a/src/transitions/misc/MCGlobalVariableRead.cpp
+++ b/src/transitions/misc/MCGlobalVariableRead.cpp
@@ -88,6 +88,6 @@ MCGlobalVariableRead::toUniqueRep() const
 void
 MCGlobalVariableRead::print() const
 {
-  mcprintf("thread %lu: READ (%s)\n", this->thread->tid,
-           this->global->varName);
+  mcprintf("thread %lu: READ (%s) [val=%lu]\n", this->thread->tid,
+           this->global->varName, this->global->val);
 }

--- a/src/transitions/misc/MCGlobalVariableWrite.cpp
+++ b/src/transitions/misc/MCGlobalVariableWrite.cpp
@@ -19,7 +19,8 @@ MCReadGlobalWrite(const MCSharedTransition *shmTransition,
                                                    globalVariable);
   }
 
-  return new MCGlobalVariableWrite(threadThatRan, globalVariable);
+  return new MCGlobalVariableWrite(threadThatRan, globalVariable,
+                                   data.value);
 }
 
 std::shared_ptr<MCTransition>
@@ -31,8 +32,8 @@ MCGlobalVariableWrite::staticCopy() const
   auto globalCpy =
     std::static_pointer_cast<MCGlobalVariable, MCVisibleObject>(
       this->global->copy());
-  auto newValueCpy = (void *)this->newValue;
-  return std::make_shared<MCGlobalVariableWrite>(threadCpy, globalCpy);
+  return std::make_shared<MCGlobalVariableWrite>(threadCpy, globalCpy,
+                                                 this->writeValue);
 }
 
 std::shared_ptr<MCTransition>
@@ -42,12 +43,16 @@ MCGlobalVariableWrite::dynamicCopyInState(const MCStack *state) const
     state->getThreadWithId(thread->tid);
   auto globalInState =
     state->getObjectWithId<MCGlobalVariable>(global->getObjectId());
-
   // TODO: Verify if copying the value directly instead of storing
   // with the associated object is correct
-  auto newValueCpy = (void *)this->newValue;
   return std::make_shared<MCGlobalVariableWrite>(
-    threadInState, globalInState);
+    threadInState, globalInState, this->writeValue);
+}
+
+void
+MCGlobalVariableWrite::applyToState(MCStack *)
+{
+  this->global->val = this->writeValue;
 }
 
 bool
@@ -93,6 +98,6 @@ MCGlobalVariableWrite::toUniqueRep() const
 void
 MCGlobalVariableWrite::print() const
 {
-  mcprintf("thread %lu: WRITE (%s)\n", this->thread->tid,
-           this->global->varName);
+  mcprintf("thread %lu: WRITE (%s = %lu)\n", this->thread->tid,
+           this->global->varName, this->writeValue);
 }

--- a/src/transitions/wrappers/MCGlobalVariableWrappers.cpp
+++ b/src/transitions/wrappers/MCGlobalVariableWrappers.cpp
@@ -18,16 +18,15 @@ mcmini_read(void *addr, char *varName)
 }
 
 void
-mcmini_write(void *addr, char *varName)
+mcmini_write(void *addr, char *varName, uint64_t value)
 {
-  auto writeData = MCGlobalVariableWriteData(addr, varName);
+  auto writeData = MCGlobalVariableWriteData(addr, varName, value);
   thread_post_visible_operation_hit<MCGlobalVariableWriteData>(
     typeid(MCGlobalVariableWrite), &writeData);
   thread_await_scheduler();
 
-  // FIXME: We don't really support writes in general. We'd
-  // need to define a template here that defined the write in
-  // general terms. What's tricky is on the side of the scheduler:
-  // each template specialization would need its own "read" handler,
-  // ideally itself defined as a template
+  // FIXME: Write-value tracking currently supports values represented as
+  // uint64_t. The LLVM instrumentation pass currently normalizes integer
+  // stores to this representation. Supporting arbitrary value types would
+  // require a generic representation & corresponding scheduler-side handling.
 }

--- a/test/data-races/llvmDataRacePass.cpp
+++ b/test/data-races/llvmDataRacePass.cpp
@@ -4,7 +4,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/InstIterator.h"
+
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/IRBuilder.h"
@@ -33,7 +33,7 @@ public:
         "mcmini_read", Type::getVoidTy(Ctx), PtrTy, PtrTy);
 
     FunctionCallee checkWriteFn = M.getOrInsertFunction(
-        "mcmini_write", Type::getVoidTy(Ctx), PtrTy, PtrTy);
+        "mcmini_write", Type::getVoidTy(Ctx), PtrTy, PtrTy, Type::getInt64Ty(Ctx));
 
     bool Changed = false;
     SmallVector<GlobalVariable *, 16> Globals;
@@ -48,43 +48,89 @@ public:
         continue;
 
       AliasAnalysis &AA = FAM.getResult<AAManager>(F);
-      for (Instruction &I : instructions(F)) {
-        IRBuilder<> Builder(&I);
-        if (auto *LI = dyn_cast<LoadInst>(&I)) {
-          Value *Ptr = LI->getPointerOperand();
-          GlobalVariable *GlobalFound = findAliasedGlobal(Ptr, Globals, AA);
-          if (GlobalFound) {
-            Builder.SetInsertPoint(LI);
-            Constant *varName = Builder.CreateGlobalStringPtr(GlobalFound->getName());
-	    Value *ptrCast = Builder.CreateBitCast(Ptr, PtrTy);
-            Builder.CreateCall(checkReadFn, {ptrCast, varName});
-            Changed = true;
-          }
-        } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
-          Value *Ptr = SI->getPointerOperand();
-          GlobalVariable *GlobalFound = findAliasedGlobal(Ptr, Globals, AA);
-          if (GlobalFound) {
-            Builder.SetInsertPoint(SI);
-            Constant *varName = Builder.CreateGlobalStringPtr(GlobalFound->getName());
-            Value *ptrCast = Builder.CreateBitCast(Ptr, PtrTy);
-            Builder.CreateCall(checkWriteFn, {ptrCast, varName});
-            Changed = true;
+
+      for (BasicBlock &BB : F) {
+        for (Instruction &I : BB) {
+          if (auto *LI = dyn_cast<LoadInst>(&I)) {
+            Value *ptr = LI->getPointerOperand();
+            GlobalVariable *GV = findTrackedGlobal(ptr, Globals, AA);
+            if (GV)
+              Changed |= instrumentGlobalRead(LI, GV, checkReadFn, PtrTy);
+          } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+            Value *ptr = SI->getPointerOperand();
+            GlobalVariable *GV = findTrackedGlobal(ptr, Globals, AA);
+            if (GV)
+              Changed |= instrumentGlobalWrite(SI, GV, checkWriteFn, PtrTy);
           }
         }
       }
     }
+
     return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
   }
 
 private:
-  GlobalVariable *findAliasedGlobal(Value *Ptr, ArrayRef<GlobalVariable *> Globals, AliasAnalysis &AA) {
+  static GlobalVariable *findTrackedGlobal(
+      Value *ptr, ArrayRef<GlobalVariable *> Globals, AliasAnalysis &AA) {
+    Value *base = ptr->stripPointerCasts();
+    while (auto *GEP = dyn_cast<GEPOperator>(base)) {
+      base = GEP->getPointerOperand()->stripPointerCasts();
+    }
+    if (auto *GV = dyn_cast<GlobalVariable>(base)) {
+      for (GlobalVariable *Candidate : Globals) {
+        if (GV == Candidate)
+          return GV;
+      }
+    }
+
     for (GlobalVariable *GV : Globals) {
-      AliasResult AR = AA.alias(Ptr, GV);
+      AliasResult AR = AA.alias(ptr, GV);
       if (AR != AliasResult::NoAlias) {
         return GV;
       }
     }
     return nullptr;
+  }
+
+  static Value *normalizeIntegerValue(IRBuilder<> &Builder, Value *value) {
+    Type *ty = value->getType();
+    if (!ty->isIntegerTy())
+      return nullptr;
+    return Builder.CreateZExtOrTrunc(value, Builder.getInt64Ty());
+  }
+
+  static bool instrumentGlobalWrite(
+      StoreInst *SI, GlobalVariable *GV,
+      FunctionCallee writeFn, Type *PtrTy) {
+    IRBuilder<> Builder(SI);
+
+    Value *storeValue = SI->getValueOperand();
+    Value *normalizedValue = normalizeIntegerValue(Builder, storeValue);
+    if (!normalizedValue)
+      return false;
+
+    Value *ptrCast = Builder.CreateBitCast(
+        SI->getPointerOperand(), PtrTy);
+    Value *name = Builder.CreateGlobalStringPtr(GV->getName());
+
+    Builder.CreateCall(writeFn, {ptrCast, name, normalizedValue});
+    return true;
+  }
+
+  static bool instrumentGlobalRead(
+      LoadInst *LI, GlobalVariable *GV,
+      FunctionCallee readFn, Type *PtrTy) {
+    Instruction *insertPt = LI->getNextNode();
+    if (!insertPt)
+      insertPt = LI->getParent()->getTerminator();
+    IRBuilder<> Builder(insertPt);
+
+    Value *ptrCast = Builder.CreateBitCast(
+        LI->getPointerOperand(), PtrTy);
+    Value *name = Builder.CreateGlobalStringPtr(GV->getName());
+
+    Builder.CreateCall(readFn, {ptrCast, name});
+    return true;
   }
 };
 } // namespace


### PR DESCRIPTION
This PR adds value tracking for global variables and improves timing measurements for livelock detection.

Global variable values are now stored as part of `MCGlobalVariable` objects and updated when write transitions are applied. This allows state comparison during livelock detection to distinguish states with the same transition structure but different global variable values. The original data race detection code remains unchanged. Extra information (the global variable value) is added on top of that to be used by the livelock code.

The addition of this extra information does not add much overhead, since it executes only in the case of global shared variables.

The LLVM instrumentation pass now captures integer store values and converts them to a 64-bit representation. Support for other data types remains future work.

This PR also changes timing output from seconds to milliseconds and reports livelock detection time separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global variable reads and writes now track and display 64-bit numeric values (in addition to name/address).
  * Global write tracking and instrumentation now propagate the tracked value into state updates.

* **Bug Fixes**
  * Revisiting-state detection now includes the most recently stored object when comparing states.
  * Global variable equality now considers both address and value for more accurate matching.

* **Performance**
  * Livelock-detection overhead reporting now uses higher-resolution timing for more precise measurement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->